### PR TITLE
Add Dataset Specialization import and fix related UI bugs

### DIFF
--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -16,7 +16,7 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 | NCIt Mapping               | ✅ Complete    | EVS REST API search + mapping resolution                             |
 | LOINC API Explorer         | ✅ Complete    | LOINC search + BC metadata integration, `routes/loinc.py`            |
 | Dataset Specializations    | ✅ Complete    | Full CRUD, BC selection (local + Library, auto-stub), bulk import via ingestion |
-| Governance Workflow        | ✅ Complete    | 4-stage Kanban board                                                 |
+| Governance Workflow        | ✅ Complete    | 4-stage Kanban board, covers both BCs and Dataset Specializations    |
 | Audit Trail                | ✅ Complete    | Filterable audit log                                                 |
 | CDISC Library API Client   | ✅ Complete    | `services/cdisc_api.py`                                              |
 | NCIt EVS API Client        | ✅ Complete    | `services/ncit_api.py`                                               |
@@ -27,6 +27,36 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 | Test Suite                 | 🚧 In Progress | BC routes, LOINC, NCIt coverage added                                |
 
 ## Daily Changelog
+
+### 2026-08-31
+
+#### Extended the Governance Workflow to Dataset Specializations
+
+- Dataset Specializations previously had no governance lifecycle at all — no `status` field, no `GovernanceRecord` linkage, no Kanban presence — while BCs had the full 4-stage `provisional → sme_review → cdisc_approval → published` workflow. Brought specializations to parity so they're tracked, advanced, and rejected the same way.
+- New Alembic migration `df33730cf8d2` — `dataset_specializations` gains `status` (default `provisional`) and `updated_at`; `governance_records.bc_id` is now nullable and a new `vlm_group_id` FK (→ `dataset_specializations.vlm_group_id`) was added, with a check constraint (`ck_governance_records_one_entity`) enforcing exactly one of `bc_id`/`vlm_group_id` is set on every row. Hit and fixed an Alembic SQLite batch-mode gotcha along the way (`create_foreign_key(None, ...)` fails with "Constraint must have a name" during a table rebuild — needs an explicit name).
+- `services/governance_service.py` — refactored `advance_governance`/`reject_bc` into shared `_advance()`/`_reject()` helpers generic over either entity type (both `BiomedicalConcept` and `DatasetSpecialization` expose `.status`/`.short_name`/`.updated_at`), then added `advance_specialization_governance()`/`reject_specialization()` on top; existing BC function signatures/return shapes unchanged.
+- `routes/governance.py` — new `POST /governance/spec/advance/<vlm_group_id>` and `POST /governance/spec/reject/<vlm_group_id>`; `board()` now also queries specializations by stage; `export()` now pulls published specializations too.
+- `templates/governance.html` — added a "Biomedical Concepts" / "Dataset Specializations" Bootstrap nav-tab toggle, each with its own 4-column Kanban board; reused the existing status-based CSS classes (`bc-badge-*`, `kanban-header-*`) since they were already generic rather than BC-specific, so no new CSS was needed. `templates/specializations.html` — added a Status badge column to the specializations list.
+- `static/js/main.js` — generalized the Kanban advance/reject click handlers to branch on `data-vlm-group-id` vs `data-bc-id` and POST to the matching endpoint, additive to the existing BC button markup.
+- `mcp_server/server.py` — added `advance_specialization_governance`/`reject_specialization` tools (parity with `advance_governance`/`reject_bc`); `list_review_queue` now includes a `specializations` key; `get_bc`'s specialization dicts now include `status`.
+- `services/export.py` — `export_governance_xlsx()` gained an optional `spec_objects` param that adds specialization worksheet(s) when given; backward compatible (defaults to `None`). (Sheet shape corrected below same day — see "Made the Governance Export Round-Trip Through the Ingestion Importer".)
+- Extended `tests/test_governance_routes.py` (new `TestSpecAdvance`/`TestSpecReject`/`TestGovernanceRecordOneEntityConstraint` classes), `tests/test_mcp_server.py`, `tests/test_specializations_routes.py`, and added a `sample_spec` fixture to `tests/conftest.py`; 312 tests passing, isort/black/flake8 clean ✅
+- Verified end-to-end against the live dev server: created a specialization, advanced it through all 4 stages and rejected it via the new routes, confirmed the `ck_governance_records_one_entity` constraint actually rejects both-null/both-set rows, and confirmed the governance XLSX export contains both worksheets.
+
+#### Fixed the Governance Board Kanban Tab Resetting on Every Advance/Reject
+
+- Reported bug: clicking Advance/Reject while on the "Dataset Specializations" tab bounced the user back to the "Biomedical Concepts" tab. Cause: the click handlers call `location.reload()` on success, and a fresh page load always renders the first Bootstrap tab as active — nothing remembered which tab had been selected.
+- `static/js/main.js` — added `initGovernanceTabs()`: on `shown.bs.tab`, the active tab's `data-bs-target` is written into the URL hash via `history.replaceState` (no extra navigation); on page load, a matching hash reactivates that tab via Bootstrap's Tab API before anything else runs. Since `location.reload()` reloads the same URL (hash included), the tab now survives the reload.
+- No Python changes; verified the rendered `data-bs-target`/hash wiring matches and the file passes `node --check`. Not click-tested in an actual browser this session (Chrome extension not installed) — asked the user to confirm.
+
+#### Made the Governance Export Round-Trip Through the Ingestion Importer
+
+- Reported bug: the Dataset Specializations sheet added to the governance XLSX export didn't match what `/ingestion/upload` expects, so an exported file couldn't be re-imported. The first cut had written a single summary sheet named "Dataset Specializations" with 7 rollup columns (`vlm_group_id, bc_id, bc_short_name, domain, short_name, status, variable_count`) — nothing like the real per-domain, per-variable worksheet shape `services/ingestion.py` parses.
+- Inspected the real reference workbook (`files/BC Examples.xlsx`) to confirm the actual expected shape: one worksheet per domain named `SDTM_<domain>` (e.g. `SDTM_LB`, `SDTM_VS` — the `SDTM_`/`CDASH_` sheet-name prefix is what `_detect_record_type()` keys off), header row = `vlm_group_id, bc_id, domain, short_name, package_date` followed by all 24 `VARIABLE_FIELDS` in their exact snake_case worksheet-column form, one row per SDTM VLM variable with the spec-level fields repeated on every row (same repeat-per-child-row pattern the `BC_LB` sheet already uses for DECs).
+- Promoted `services/ingestion._SPEC_HEADER_FIELDS` to a public `SPEC_HEADER_FIELDS` (now needed by `services/export.py` too) and rewrote `export_governance_xlsx()`'s specialization branch to group `spec_objects` by `domain`, create one `SDTM_<domain>` sheet per group, and emit rows in the importer's exact shape (a specialization with zero variables still emits one header-only row so it round-trips instead of silently disappearing).
+- Added `TestExportGovernanceXlsxSpecializations` to `tests/test_export_service.py`, including a round-trip test that feeds the exported `BytesIO` straight into `services.ingestion.parse_xlsx()` and asserts the resulting record matches the original; 318 tests passing, isort/black/flake8 clean ✅
+- Verified against the live dev server with the real HTTP path end-to-end: created a specialization with a variable via the UI, advanced it to published, downloaded `/governance/export`, and re-uploaded that exact file through `/ingestion/upload` — it parsed back out as a `Dataset Specialization` ingestion record with the same `vlm_group_id`/`bc_id`/`domain`/variables.
+- **Follow-up same day**: the header row above was importer-parseable but not byte-for-byte identical to the reference file — column order was wrong (`vlm_group_id, bc_id, domain, short_name, package_date, ...`) and it was missing 3 real columns the reference sheet has (`sdtmig_start_version`, `sdtmig_end_version`, `vlm_source`) that the model doesn't track but the importer still expects to see as headers. Read `files/BC Examples.xlsx`'s `SDTM_LB`/`SDTM_VS` sheets directly to get the exact column order, added `services/export.py:SPEC_SHEET_HEADER_FIELDS` matching it exactly (the 3 untracked columns are exported blank rather than omitted), and switched the test to assert the literal reference header list instead of deriving it from the same constant the implementation uses. Verified with a direct `openpyxl` diff between the reference file's header row and a live export's — exact match.
 
 ### 2026-08-28
 

--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -11,11 +11,11 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 | Flask App Foundation       | ✅ Complete    | `app.py`, `extensions.py`, `config.py`                               |
 | Database Models            | ✅ Complete    | BC, DEC, Governance, Audit, Ingestion, Specialization                |
 | Dashboard                  | ✅ Complete    | KPI stats, live CDISC Library API counts + BC/Spec panels, route `/` |
-| Ingestion (Upload + Parse) | ✅ Complete    | XLSX/CSV/JSON upload, AI field mapping, BC/DEC grouping              |
+| Ingestion (Upload + Parse) | ✅ Complete    | XLSX/CSV/JSON upload, AI field mapping, BC/DEC + Specialization grouping |
 | BC CRUD + Export           | ✅ Complete    | JSON/XLSX/ODM-XML export                                             |
 | NCIt Mapping               | ✅ Complete    | EVS REST API search + mapping resolution                             |
 | LOINC API Explorer         | ✅ Complete    | LOINC search + BC metadata integration, `routes/loinc.py`            |
-| Dataset Specializations    | ✅ Complete    | Full CRUD, BC selection, fixed search                                |
+| Dataset Specializations    | ✅ Complete    | Full CRUD, BC selection (local + Library, auto-stub), bulk import via ingestion |
 | Governance Workflow        | ✅ Complete    | 4-stage Kanban board                                                 |
 | Audit Trail                | ✅ Complete    | Filterable audit log                                                 |
 | CDISC Library API Client   | ✅ Complete    | `services/cdisc_api.py`                                              |
@@ -27,6 +27,40 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 | Test Suite                 | 🚧 In Progress | BC routes, LOINC, NCIt coverage added                                |
 
 ## Daily Changelog
+
+### 2026-08-28
+
+#### Added Dataset Specialization Import + Fixed the BC-Picker Orphan-FK Gap
+
+- The Specializations page was blank because there was no bulk-import path into `dataset_specializations` — only one-at-a-time manual entry or "Generate from DEC Templates" existed. Taught the existing `/ingestion` upload+review pipeline (previously BC-only) to also recognize and import SDTM Dataset Specialization rows from the same curation workbooks (e.g. `files/BC Examples.xlsx`, whose `SDTM_LB`/`SDTM_VS` sheets are specializations joined to a BC via `bc_id`)
+- `services/ingestion.py` — added `SPEC_FIELD_MAP`, `_detect_record_type()` (sheet-name prefix `BC_`/`SDTM_`/`CDASH_` first, falls back to a `vlm_group_id` column signature), `validate_specialization()`, `_group_by_spec()` (groups VLM variable rows by `vlm_group_id`, mirroring `_group_by_bc`'s DEC grouping); parameterized `map_fields()`/`_match_field()` to accept a field map; `parse_xlsx/csv/json` and `deduplicate()` now branch by record type
+- `models/ingestion.py` — added `record_type` column (`"bc"` / `"specialization"`, new migration `95643d73ac0e`); `models/specialization.py` — `created_at` now actually defaults instead of always being `NULL`
+- `routes/ingestion.py` — `approve()`/`approve_all()` now create `DatasetSpecialization` rows too; `approve_all()` resolves all BC-type records first (flushed) before specialization-type ones, so a single workbook mixing `BC_`/`SDTM_` sheets imports correctly in one click; a specialization whose BC doesn't exist yet is left `pending` with a flash error instead of orphaning or crashing
+- `routes/specializations.py` — `create()` now auto-creates a minimal local BC stub (new `services/bc_service.get_or_create_bc_stub()`) when a user picks a CDISC-Library-only BC on the manual Specialization form, fixing a real gap: SQLite FK enforcement is off, so that path previously created specializations with no matching local BC row; also sorted the Library `<optgroup>` alphabetically (it was the only unsorted one)
+- `templates/ingestion.html` — split the review queue into separate "Biomedical Concepts" / "Dataset Specializations" sections; `templates/specializations.html` — fixed two dead-attribute bugs (`spec.bc_name`, `spec.variable_count` don't exist on the model) that were silently showing raw `bc_id` and "0 variables" for every row
+- Caught via manual smoke test (not just unit tests): the worksheet's `domain` column holds the real SDTM domain codelist value (`LB`, `VS`, ...), not an `SDTM`/`CDASH` toggle — an early version of this change incorrectly forced a literal `"SDTM"` constant; corrected to map the real column value through
+- Added `tests/test_bc_service.py` and extended `tests/test_ingestion_service.py`, `tests/test_ingestion_routes.py`, `tests/test_specializations_routes.py` — 280 tests passing, isort/black/flake8 clean ✅
+- Verified end-to-end against the real `files/BC Examples.xlsx`: 25 BCs + 23 specializations parsed, 25 BCs + 22 specializations approved (1 correctly held pending — its BC wasn't in that workbook's BC sheets)
+
+#### Replaced the Manual Specialization Form's SDTM/CDASH Toggle with a Real SDTM Domain Codelist Dropdown
+
+- The manual "Add Specialization" form previously let `domain` be either the literal string `SDTM` or `CDASH` via a radio toggle — meaningless once the ingestion import above started populating `domain` with real SDTM domain codes (`LB`, `VS`, ...). Replaced the toggle with a `<select>` populated live from the CDISC Library's own SDTM Domain Abbreviation codelist (C66734), so only real, current domain codes can be chosen
+- `services/cdisc_api.py` — added `get_ct_packages()` (lists all CT packages from the Library's general MDR API at `LIBRARY_BASE_URL = "https://library.cdisc.org/api"`, a different host/path than the COSMoS-specific base this client otherwise uses) and `get_sdtm_domain_codes()` (picks the most recent `sdtmct-*` package by date-sorted href, fetches codelist `C66734`, returns `[{code, label}]` from each term's `submissionValue`/`preferredTerm`, cached like the existing BC/specialization list calls); verified the exact response shape against the live API before writing code against it
+- `routes/specializations.py` — `index()`/`detail()` now pass `domain_codes` into the template; `create()`/`generate()` now require a non-blank `domain` (previously silently defaulted to `"SDTM"`)
+- `templates/specializations.html` — domain `<select>` shows `"CODE — Preferred Term"` options, with a fallback option so editing an existing spec whose domain code has since been retired/superseded doesn't silently blank the field; dropped the SDTM-vs-CDASH conditional badge coloring in the list view (domain is now an open codelist, not a two-value toggle); updated the "Generate from DEC Templates" JS to read the select instead of a checked radio
+- `models/specialization.py` — corrected the stale `# SDTM or CDASH` comment on `domain`
+- Extended `tests/test_cdisc_api_cache.py` (new package/codelist fetch tests, mocked at the `requests.get` level per this file's existing convention) and `tests/test_specializations_routes.py` (domain required, real domain code persists, dropdown rendered from the mocked codelist); 290 tests passing, isort/black/flake8 clean ✅
+- Verified live against the real CDISC Library API (real API key already in this shell's env) that the dropdown renders all 85 real SDTM domain codes from the current package (e.g. `AE — Adverse Event Domain`, `VS — Vital Signs Domain`)
+
+#### Fixed the Edit Button + Rebuilt Variable Import Against Real Worksheet Columns (not a synthesized name/label/data_type/required shape)
+
+- **Edit button did nothing**: `specializations.detail()` renders the same template with `edit_spec` populated, but the pre-filled form lives in a Bootstrap `collapse` div that was never told to expand — the page loaded correctly but the form stayed hidden. `templates/specializations.html` now adds the `show` class whenever `edit_spec` is set.
+- **Variables were imported wrong**: for specialization `KETONESURIN`, the worksheet has 11 rows (`sdtm_variable` column), but only 8 garbled entries were showing (e.g. `KETONES`, `URINALYSIS`, `mmol/L` instead of `LBTESTCD`, `LBORRES`, ...). Root cause: `SPEC_FIELD_MAP` only had ~8 curated canonical fields, so the ~20 other real VLM columns (`dec_id`, `codelist`, `assigned_value`, `subject`, `object`, `predicate_term`, ...) fuzzy-matched onto those few fields with score > 0.5 and silently overwrote them within the same row — `assigned_value` was literally clobbering `sdtm_variable` itself.
+- Fixed by mapping **every real worksheet column (I-AF, 24 variable-level fields) 1:1 to itself** instead of a small curated+fuzzy list — `services/ingestion.py` now has `VARIABLE_FIELD_DEFS`/`VARIABLE_FIELDS` (the full column list: `sdtm_variable`, `dec_id`, `nsv_flag`, `codelist`, `codelist_submission_value`, `subset_codelist`, `value_list`, `assigned_term`, `assigned_value`, `role`, `subject`, `linking_phrase`, `predicate_term`, `object`, `data_type`, `length`, `format`, `significant_digits`, `mandatory_variable`, `mandatory_value`, `origin_type`, `origin_source`, `comparator`, `vlm_target`), each scoring 1.0 against itself so same-row collisions between similarly-named columns (e.g. `mandatory_variable` vs `mandatory_value`) are now structurally impossible; `_group_by_spec()` builds one full-width dict per variable row instead of the old synthesized `{name, label, data_type, required}` shape
+- Dropped the fabricated `label`/`required` fields (not real worksheet columns) per explicit instruction — the UI's variable table now shows/edits exactly the worksheet's I-AF columns, driven from a single `variable_field_defs` list shared between `routes/specializations.py` and the template (header row, form field names, and the JS that builds new/generated rows all read from it, so there's one source of truth instead of three copies)
+- `routes/specializations.py` — `_variables_from_form()` rewritten to parse all `VARIABLE_FIELDS` per row (gated on `sdtm_variable` being non-blank); `_variable_from_dec()` seeds `sdtm_variable`/`dec_id`/`data_type` from a BC's DataElementConcept for the "Generate from DEC Templates" flow, leaving the columns a DEC can't supply blank for the user to fill in
+- Updated `tests/test_ingestion_service.py`, `tests/test_specializations_routes.py` for the new shape; 293 tests passing, flake8 clean ✅
+- Verified end-to-end against the real workbook: `KETONESURIN` now shows exactly 11 variable rows with correct values in the right order (`LBTESTCD`, `LBTEST`, `LBCAT`, `LBORRES`, `LBORRESU`, `LBSTRESC`, `LBSTRESN`, `LBSTRESU`, `LBLOINC`, `LBSPEC`, `LBFAST`), and the Edit link now opens the form expanded
 
 ### 2026-08-03
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -17,14 +17,16 @@ Read tools (8):
   get_library_bc        Fetch one published BC from the CDISC Library
   list_review_queue     Governance board summary + pending ingestion count
 
-Write tools (6) — same service code path as the web routes, every write
+Write tools (8) — same service code path as the web routes, every write
 audited; actor defaults to "mcp" so agent writes are distinguishable:
-  create_bc             Create a provisional BC (optionally with DECs)
-  update_bc             Update BC fields
-  map_ncit_to_bc        Attach an NCIt code (promotes IMPORT_ ids)
-  submit_bc_for_review  provisional -> sme_review
-  advance_governance    Advance one governance stage
-  reject_bc             Reject back to provisional
+  create_bc                          Create a provisional BC (optionally with DECs)
+  update_bc                          Update BC fields
+  map_ncit_to_bc                     Attach an NCIt code (promotes IMPORT_ ids)
+  submit_bc_for_review               provisional -> sme_review
+  advance_governance                 Advance one governance stage (BC)
+  reject_bc                          Reject back to provisional (BC)
+  advance_specialization_governance  Advance one governance stage (Dataset Specialization)
+  reject_specialization              Reject back to provisional (Dataset Specialization)
 """
 
 import asyncio
@@ -269,6 +271,35 @@ _TOOLS = [
             "required": ["bc_id"],
         },
     ),
+    types.Tool(
+        name="advance_specialization_governance",
+        description=(
+            "Advance a Dataset Specialization one stage (provisional -> sme_review -> cdisc_approval -> published). "
+            "Writes a GovernanceRecord and an audit entry; returns advanced=false if already published."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "vlm_group_id": {"type": "string"},
+                "comment": {"type": "string"},
+                "actor": {"type": "string", "default": "mcp"},
+            },
+            "required": ["vlm_group_id"],
+        },
+    ),
+    types.Tool(
+        name="reject_specialization",
+        description="Reject a Dataset Specialization back to provisional (stage 0). Writes a GovernanceRecord and an audit entry.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "vlm_group_id": {"type": "string"},
+                "comment": {"type": "string"},
+                "actor": {"type": "string", "default": "mcp"},
+            },
+            "required": ["vlm_group_id"],
+        },
+    ),
 ]
 
 
@@ -305,6 +336,8 @@ def _dispatch(name: str, args: dict) -> Any:
         "submit_bc_for_review": _submit_bc_for_review,
         "advance_governance": _advance_governance,
         "reject_bc": _reject_bc,
+        "advance_specialization_governance": _advance_specialization_governance,
+        "reject_specialization": _reject_specialization,
     }
     fn = handlers.get(name)
     if fn is None:
@@ -389,6 +422,7 @@ def _get_bc(args: dict) -> dict:
             "domain": s.domain,
             "short_name": s.short_name,
             "variables": s.variables,
+            "status": s.status,
         }
         for s in bc.specializations
     ]
@@ -464,15 +498,20 @@ def _get_library_bc(args: dict) -> dict:
 def _list_review_queue(_args: dict) -> dict:
     from models.bc import BiomedicalConcept
     from models.ingestion import IngestionRecord
+    from models.specialization import DatasetSpecialization
 
     queue = {}
+    spec_queue = {}
     for status in ("sme_review", "cdisc_approval"):
         bcs = BiomedicalConcept.query.filter_by(status=status).order_by(BiomedicalConcept.updated_at.desc()).all()
         queue[status] = [{"bc_id": bc.bc_id, "short_name": bc.short_name, "submitter": bc.submitter, "updated_at": bc.updated_at} for bc in bcs]
+        specs = DatasetSpecialization.query.filter_by(status=status).order_by(DatasetSpecialization.updated_at.desc()).all()
+        spec_queue[status] = [{"vlm_group_id": s.vlm_group_id, "bc_id": s.bc_id, "short_name": s.short_name, "updated_at": s.updated_at} for s in specs]
     pending_ingestion = IngestionRecord.query.filter_by(status="pending").count()
     return {
         "sme_review": queue["sme_review"],
         "cdisc_approval": queue["cdisc_approval"],
+        "specializations": spec_queue,
         "pending_ingestion_records": pending_ingestion,
     }
 
@@ -551,6 +590,28 @@ def _reject_bc(args: dict) -> dict:
         raise ValueError("bc_id is required")
     actor = str(args.get("actor") or "mcp")
     return governance_service.reject_bc(bc_id, actor=actor, comment=str(args.get("comment") or ""))
+
+
+@_with_app_context
+def _advance_specialization_governance(args: dict) -> dict:
+    from services import governance_service
+
+    vlm_group_id = str(args.get("vlm_group_id") or "").strip()
+    if not vlm_group_id:
+        raise ValueError("vlm_group_id is required")
+    actor = str(args.get("actor") or "mcp")
+    return governance_service.advance_specialization_governance(vlm_group_id, actor=actor, comment=str(args.get("comment") or ""))
+
+
+@_with_app_context
+def _reject_specialization(args: dict) -> dict:
+    from services import governance_service
+
+    vlm_group_id = str(args.get("vlm_group_id") or "").strip()
+    if not vlm_group_id:
+        raise ValueError("vlm_group_id is required")
+    actor = str(args.get("actor") or "mcp")
+    return governance_service.reject_specialization(vlm_group_id, actor=actor, comment=str(args.get("comment") or ""))
 
 
 # ---------------------------------------------------------------------------

--- a/migrations/versions/95643d73ac0e_add_record_type_to_ingestion_records.py
+++ b/migrations/versions/95643d73ac0e_add_record_type_to_ingestion_records.py
@@ -1,0 +1,26 @@
+"""add record_type to ingestion_records
+
+Revision ID: 95643d73ac0e
+Revises: 51d4a009d291
+Create Date: 2026-08-28 15:16:03.771535
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "95643d73ac0e"
+down_revision = "51d4a009d291"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("ingestion_records", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("record_type", sa.String(length=20), nullable=False, server_default="bc"))
+
+
+def downgrade():
+    with op.batch_alter_table("ingestion_records", schema=None) as batch_op:
+        batch_op.drop_column("record_type")

--- a/migrations/versions/df33730cf8d2_add_governance_status_to_specializations.py
+++ b/migrations/versions/df33730cf8d2_add_governance_status_to_specializations.py
@@ -1,0 +1,45 @@
+"""add governance status to specializations
+
+Revision ID: df33730cf8d2
+Revises: 95643d73ac0e
+Create Date: 2026-08-31 13:03:31.303332
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "df33730cf8d2"
+down_revision = "95643d73ac0e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("dataset_specializations", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("status", sa.String(length=50), nullable=False, server_default="provisional"))
+        batch_op.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
+
+    op.execute("UPDATE dataset_specializations SET updated_at = created_at")
+
+    with op.batch_alter_table("governance_records", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("vlm_group_id", sa.String(length=100), nullable=True))
+        batch_op.alter_column("bc_id", existing_type=sa.VARCHAR(length=50), nullable=True)
+        batch_op.create_foreign_key("fk_governance_records_vlm_group_id", "dataset_specializations", ["vlm_group_id"], ["vlm_group_id"])
+        batch_op.create_check_constraint(
+            "ck_governance_records_one_entity",
+            "(bc_id IS NOT NULL) + (vlm_group_id IS NOT NULL) = 1",
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("governance_records", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_governance_records_one_entity", type_="check")
+        batch_op.drop_constraint("fk_governance_records_vlm_group_id", type_="foreignkey")
+        batch_op.alter_column("bc_id", existing_type=sa.VARCHAR(length=50), nullable=False)
+        batch_op.drop_column("vlm_group_id")
+
+    with op.batch_alter_table("dataset_specializations", schema=None) as batch_op:
+        batch_op.drop_column("updated_at")
+        batch_op.drop_column("status")

--- a/models/governance.py
+++ b/models/governance.py
@@ -5,8 +5,15 @@ from extensions import db
 
 class GovernanceRecord(db.Model):
     __tablename__ = "governance_records"
+    __table_args__ = (
+        db.CheckConstraint(
+            "(bc_id IS NOT NULL) + (vlm_group_id IS NOT NULL) = 1",
+            name="ck_governance_records_one_entity",
+        ),
+    )
     id = db.Column(db.Integer, primary_key=True)
-    bc_id = db.Column(db.String(50), db.ForeignKey("biomedical_concepts.bc_id"), nullable=False)
+    bc_id = db.Column(db.String(50), db.ForeignKey("biomedical_concepts.bc_id"), nullable=True)
+    vlm_group_id = db.Column(db.String(100), db.ForeignKey("dataset_specializations.vlm_group_id"), nullable=True)
     stage = db.Column(db.Integer, default=0)  # 0=Scoping, 1=Development, 2=Draft, 3a=Internal Review, 3b=Public Review, 3c=Publication, 4=Maintenance
     action = db.Column(db.String(100))  # submitted, advanced, rejected, approved, published
     actor = db.Column(db.String(100))
@@ -14,3 +21,4 @@ class GovernanceRecord(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
 
     bc = db.relationship("BiomedicalConcept", backref=db.backref("governance_records", lazy="dynamic"))
+    specialization = db.relationship("DatasetSpecialization", backref=db.backref("governance_records", lazy="dynamic"))

--- a/models/ingestion.py
+++ b/models/ingestion.py
@@ -13,7 +13,8 @@ class IngestionRecord(db.Model):
     _mapped = db.Column("mapped", db.Text)
     _confidences = db.Column("confidences", db.Text)
     _errors = db.Column("errors", db.Text)
-    _decs = db.Column("decs", db.Text)
+    _decs = db.Column("decs", db.Text)  # DEC sub-rows for a BC record, variable rows for a specialization record
+    record_type = db.Column(db.String(20), default="bc", nullable=False)  # "bc" / "specialization"
     duplicate = db.Column(db.Boolean, default=False)
     status = db.Column(db.String(20), default="pending")  # pending / approved / rejected
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))

--- a/models/specialization.py
+++ b/models/specialization.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 
 from extensions import db
 
@@ -7,10 +8,10 @@ class DatasetSpecialization(db.Model):
     __tablename__ = "dataset_specializations"
     vlm_group_id = db.Column(db.String(100), primary_key=True)
     bc_id = db.Column(db.String(50), db.ForeignKey("biomedical_concepts.bc_id"), nullable=False)
-    domain = db.Column(db.String(20))  # SDTM or CDASH
+    domain = db.Column(db.String(20))  # SDTM Domain Abbreviation codelist (C66734) submissionValue, e.g. "LB", "VS"
     short_name = db.Column(db.String(255))
     _variables = db.Column("variables", db.Text, default="[]")
-    created_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
 
     @property
     def variables(self):

--- a/models/specialization.py
+++ b/models/specialization.py
@@ -11,7 +11,9 @@ class DatasetSpecialization(db.Model):
     domain = db.Column(db.String(20))  # SDTM Domain Abbreviation codelist (C66734) submissionValue, e.g. "LB", "VS"
     short_name = db.Column(db.String(255))
     _variables = db.Column("variables", db.Text, default="[]")
+    status = db.Column(db.String(50), default="provisional")  # provisional/sme_review/cdisc_approval/published
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     @property
     def variables(self):
@@ -28,4 +30,5 @@ class DatasetSpecialization(db.Model):
             "domain": self.domain,
             "short_name": self.short_name,
             "variables": self.variables,
+            "status": self.status,
         }

--- a/routes/governance.py
+++ b/routes/governance.py
@@ -4,6 +4,7 @@ from flask import Blueprint, Response, flash, jsonify, redirect, render_template
 
 from extensions import db
 from models.bc import BiomedicalConcept
+from models.specialization import DatasetSpecialization
 from services import governance_service
 from services.export import export_governance_xlsx
 from services.governance_service import STATUS_ORDER
@@ -16,11 +17,14 @@ bp = Blueprint("governance", __name__)
 @bp.route("/board")
 def board():
     bcs_by_status = {}
+    specs_by_status = {}
     for status in STATUS_ORDER:
         bcs_by_status[status] = BiomedicalConcept.query.filter_by(status=status).order_by(BiomedicalConcept.updated_at.desc()).all()
+        specs_by_status[status] = DatasetSpecialization.query.filter_by(status=status).order_by(DatasetSpecialization.updated_at.desc()).all()
     return render_template(
         "governance.html",
         columns=bcs_by_status,
+        spec_columns=specs_by_status,
         status_order=STATUS_ORDER,
         page_title="Governance Board",
     )
@@ -36,8 +40,9 @@ def export():
     safe_filename = f"{base}.xlsx"
 
     bcs = BiomedicalConcept.query.filter_by(status="published").all()
+    specs = DatasetSpecialization.query.filter_by(status="published").all()
 
-    buf = export_governance_xlsx(bcs)
+    buf = export_governance_xlsx(bcs, specs)
     return Response(
         buf,
         mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -64,5 +69,28 @@ def reject_bc(bc_id):
     result = governance_service.reject_bc(bc_id, actor="user", comment=request.form.get("comment", ""))
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         return jsonify({"status": "provisional", "bc_id": bc_id})
+    flash(f'{result["short_name"]} rejected and returned to provisional', "warning")
+    return redirect(url_for("governance.board"))
+
+
+@bp.route("/spec/advance/<vlm_group_id>", methods=["POST"])
+def advance_spec(vlm_group_id):
+    db.get_or_404(DatasetSpecialization, vlm_group_id)
+    result = governance_service.advance_specialization_governance(vlm_group_id, actor="user", comment=request.form.get("comment", ""))
+    if result["advanced"]:
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify({"status": result["status"], "vlm_group_id": vlm_group_id})
+        flash(f'{result["short_name"]} advanced to {result["status"]}', "success")
+    else:
+        flash(f'{result["short_name"]} is already published', "info")
+    return redirect(url_for("governance.board"))
+
+
+@bp.route("/spec/reject/<vlm_group_id>", methods=["POST"])
+def reject_spec(vlm_group_id):
+    db.get_or_404(DatasetSpecialization, vlm_group_id)
+    result = governance_service.reject_specialization(vlm_group_id, actor="user", comment=request.form.get("comment", ""))
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return jsonify({"status": "provisional", "vlm_group_id": vlm_group_id})
     flash(f'{result["short_name"]} rejected and returned to provisional', "warning")
     return redirect(url_for("governance.board"))

--- a/routes/ingestion.py
+++ b/routes/ingestion.py
@@ -15,6 +15,8 @@ from extensions import db
 from models.audit import AuditLog
 from models.bc import BiomedicalConcept, DataElementConcept
 from models.ingestion import IngestionRecord
+from models.specialization import DatasetSpecialization
+from services.audit import log_change
 from services.ingestion import deduplicate, parse_csv, parse_json, parse_xlsx
 
 logger = logging.getLogger(__name__)
@@ -68,6 +70,33 @@ def _create_decs(bc_id, decs):
         db.session.add(dec)
 
 
+def _approve_spec_record(ir):
+    """Create a DatasetSpecialization from a pending specialization-type
+    IngestionRecord. Returns True if the record should be marked approved
+    (created, or already existed), False if it must stay pending (its BC
+    doesn't exist locally yet)."""
+    mapped = ir.mapped
+    vlm_group_id = mapped.get("vlm_group_id", "")
+    bc_id = mapped.get("bc_id", "")
+    if not db.session.get(BiomedicalConcept, bc_id):
+        flash(f"Cannot import {vlm_group_id}: BC {bc_id} not found locally — approve/import that BC first", "danger")
+        return False
+    if db.session.get(DatasetSpecialization, vlm_group_id):
+        flash(f"Specialization {vlm_group_id} already exists", "warning")
+        return True
+    spec = DatasetSpecialization(
+        vlm_group_id=vlm_group_id,
+        bc_id=bc_id,
+        domain=mapped.get("domain", ""),
+        short_name=mapped.get("short_name", ""),
+    )
+    spec.variables = ir.decs
+    db.session.add(spec)
+    log_change("DatasetSpecialization", vlm_group_id, "created_via_ingestion", actor="system", after=spec.to_dict())
+    flash(f"Specialization {vlm_group_id} added", "success")
+    return True
+
+
 @bp.route("/")
 def index():
     key = session.get("ingestion_key")
@@ -87,6 +116,7 @@ def upload():
 
     ext = f.filename.rsplit(".", 1)[1].lower()
     existing_ids = {bc.bc_id for bc in BiomedicalConcept.query.with_entities(BiomedicalConcept.bc_id).all()}
+    existing_spec_ids = {s.vlm_group_id for s in DatasetSpecialization.query.with_entities(DatasetSpecialization.vlm_group_id).all()}
 
     if ext == "xlsx":
         records = parse_xlsx(f)
@@ -95,7 +125,7 @@ def upload():
     else:
         records = parse_json(f)
 
-    records = deduplicate(records, existing_ids)
+    records = deduplicate(records, existing_ids, existing_spec_ids=existing_spec_ids)
 
     key = _get_session_key()
     IngestionRecord.query.filter_by(session_key=key, status="pending").delete()
@@ -105,12 +135,13 @@ def upload():
             session_key=key,
             source_file=f.filename,
             source_sheet=rec.get("source_sheet", ""),
+            record_type=rec.get("record_type", "bc"),
             duplicate=rec.get("duplicate", False),
         )
         ir.mapped = rec.get("mapped", {})
         ir.confidences = rec.get("confidences", {})
         ir.errors = rec.get("errors", [])
-        ir.decs = rec.get("decs", [])
+        ir.decs = rec.get("decs") or rec.get("variables") or []
         db.session.add(ir)
 
     db.session.commit()
@@ -121,6 +152,12 @@ def upload():
 @bp.route("/approve/<int:record_id>", methods=["POST"])
 def approve(record_id):
     ir = db.get_or_404(IngestionRecord, record_id)
+    if ir.record_type == "specialization":
+        if _approve_spec_record(ir):
+            ir.status = "approved"
+        db.session.commit()
+        return redirect(url_for("ingestion.index"))
+
     mapped = ir.mapped
     bc_id = mapped.get("bc_id") or mapped.get("ncit_code", f"IMPORT_{record_id}")
     if not db.session.get(BiomedicalConcept, bc_id):
@@ -157,8 +194,11 @@ def approve_all():
     if not key:
         return redirect(url_for("ingestion.index"))
     pending = IngestionRecord.query.filter_by(session_key=key, status="pending").all()
-    added = 0
-    for ir in pending:
+    bc_records = [ir for ir in pending if ir.record_type != "specialization"]
+    spec_records = [ir for ir in pending if ir.record_type == "specialization"]
+
+    added_bc = 0
+    for ir in bc_records:
         if ir.errors or ir.duplicate:
             ir.status = "rejected"
             continue
@@ -178,9 +218,22 @@ def approve_all():
                 )
             )
             ir.status = "approved"
-            added += 1
+            added_bc += 1
         else:
             ir.status = "approved"
+    # Flush so newly-created BCs are visible to the bc_id existence check below.
+    db.session.flush()
+
+    added_spec = 0
+    for ir in spec_records:
+        if ir.errors or ir.duplicate:
+            ir.status = "rejected"
+            continue
+        if _approve_spec_record(ir):
+            ir.status = "approved"
+            added_spec += 1
+        # else: leave pending so the user can retry once its BC is approved.
+
     db.session.commit()
-    flash(f"Approved {added} BCs", "success")
+    flash(f"Approved {added_bc} BCs and {added_spec} specializations", "success")
     return redirect(url_for("ingestion.index"))

--- a/routes/specializations.py
+++ b/routes/specializations.py
@@ -6,7 +6,9 @@ from extensions import db
 from models.bc import BiomedicalConcept, DataElementConcept
 from models.specialization import DatasetSpecialization
 from services.audit import log_change
+from services.bc_service import get_or_create_bc_stub
 from services.cdisc_api import CDISCApiClient
+from services.ingestion import VARIABLE_FIELD_DEFS, VARIABLE_FIELDS
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +23,28 @@ def _get_bc_options():
     """
     links = CDISCApiClient().get_biomedical_concepts()
     library_bcs = [{"bc_id": lnk["href"].rstrip("/").split("/")[-1], "short_name": lnk.get("title", "")} for lnk in links if "href" in lnk and "error" not in lnk]
+    library_bcs.sort(key=lambda bc: bc["short_name"].lower())
     local_bcs = BiomedicalConcept.query.order_by(BiomedicalConcept.short_name).all()
     return library_bcs, local_bcs
+
+
+def _get_domain_codes():
+    """Return the SDTM Domain Abbreviation codelist (C66734) as [{code, label}, ...]
+    from the most recent SDTM CT package, for the domain selector."""
+    codes = CDISCApiClient().get_sdtm_domain_codes()
+    return [c for c in codes if c.get("code")]
+
+
+def _variable_from_dec(dec):
+    """Best-effort variable row seeded from a BC's Data Element Concept.
+    A DEC doesn't carry most VLM columns (codelist, role, subject, ...), so
+    only sdtm_variable/dec_id/data_type are populated — the rest are left
+    blank for the user to fill in."""
+    row = dict.fromkeys(VARIABLE_FIELDS, "")
+    row["sdtm_variable"] = dec.dec_label or ""
+    row["dec_id"] = dec.dec_id or ""
+    row["data_type"] = dec.data_type or "string"
+    return row
 
 
 @bp.route("/")
@@ -34,6 +56,8 @@ def index():
         specializations=specs,
         library_bcs=library_bcs,
         local_bcs=local_bcs,
+        domain_codes=_get_domain_codes(),
+        variable_field_defs=VARIABLE_FIELD_DEFS,
         page_title="Specializations",
     )
 
@@ -62,27 +86,23 @@ def detail(vlm_group_id):
         specializations=specs,
         library_bcs=library_bcs,
         local_bcs=local_bcs,
+        domain_codes=_get_domain_codes(),
+        variable_field_defs=VARIABLE_FIELD_DEFS,
         edit_spec=spec,
         page_title="Specializations",
     )
 
 
 def _variables_from_form(form):
-    """Convert the bracketed variables[i][field] form inputs into a list of dicts."""
+    """Convert the bracketed variables[i][field] form inputs into a list of
+    dicts, one per VARIABLE_FIELDS column (the same worksheet columns
+    services.ingestion imports from SDTM_/CDASH_ sheets)."""
     variables = []
     i = 0
-    while f"variables[{i}][name]" in form:
-        name = (form.get(f"variables[{i}][name]") or "").strip()
-        label = (form.get(f"variables[{i}][label]") or "").strip()
-        if name or label:
-            variables.append(
-                {
-                    "name": name,
-                    "label": label,
-                    "data_type": form.get(f"variables[{i}][data_type]") or "string",
-                    "required": form.get(f"variables[{i}][required]") == "on",
-                }
-            )
+    while f"variables[{i}][sdtm_variable]" in form:
+        row = {field: (form.get(f"variables[{i}][{field}]") or "").strip() for field in VARIABLE_FIELDS}
+        if row["sdtm_variable"]:
+            variables.append(row)
         i += 1
     return variables
 
@@ -91,12 +111,14 @@ def _variables_from_form(form):
 def create():
     vlm_group_id = request.form.get("vlm_group_id", "").strip()
     bc_id = request.form.get("bc_id", "").strip()
-    if not vlm_group_id or not bc_id:
-        flash("VLM Group ID and BC are required", "danger")
+    domain = request.form.get("domain", "").strip()
+    if not vlm_group_id or not bc_id or not domain:
+        flash("VLM Group ID, BC, and Domain are required", "danger")
         return redirect(url_for("specializations.index"))
-    domain = request.form.get("domain", "SDTM")
     short_name = request.form.get("short_name", "")
     variables = _variables_from_form(request.form)
+
+    get_or_create_bc_stub(bc_id, short_name=short_name, actor="user")
 
     spec = db.session.get(DatasetSpecialization, vlm_group_id)
     if spec:
@@ -142,7 +164,7 @@ def generate_from_dec():
     if not bc_id:
         return jsonify({"error": "bc_id required"}), 400
     decs = DataElementConcept.query.filter_by(bc_id=bc_id).all()
-    variables = [{"name": d.dec_label or "", "label": d.dec_label or "", "data_type": d.data_type or "string", "required": bool(d.required)} for d in decs]
+    variables = [_variable_from_dec(d) for d in decs]
     return jsonify({"variables": variables})
 
 
@@ -151,13 +173,16 @@ def generate(bc_id):
     """Generate a specialization from DEC templates for a BC."""
     bc = db.get_or_404(BiomedicalConcept, bc_id)
     decs = DataElementConcept.query.filter_by(bc_id=bc_id).all()
-    domain = request.form.get("domain", "SDTM")
+    domain = request.form.get("domain", "").strip()
+    if not domain:
+        flash("Domain is required", "danger")
+        return redirect(url_for("specializations.index"))
     vlm_group_id = f"{bc_id}.{domain}"
     existing = db.session.get(DatasetSpecialization, vlm_group_id)
     if existing:
         flash(f"Specialization {vlm_group_id} already exists", "warning")
         return redirect(url_for("specializations.index"))
-    variables = [{"name": d.dec_label, "data_type": d.data_type, "required": d.required} for d in decs]
+    variables = [_variable_from_dec(d) for d in decs]
     spec = DatasetSpecialization(
         vlm_group_id=vlm_group_id,
         bc_id=bc_id,

--- a/services/bc_service.py
+++ b/services/bc_service.py
@@ -85,6 +85,16 @@ def create_bc(data, actor=None):
     return bc
 
 
+def get_or_create_bc_stub(bc_id, short_name="", actor=None):
+    """Return the local BC for bc_id, creating a minimal provisional stub if
+    none exists yet (e.g. when a user picks a CDISC-Library-only BC on a
+    form that requires a local bc_id to link against)."""
+    bc = db.session.get(BiomedicalConcept, bc_id)
+    if bc:
+        return bc
+    return create_bc({"bc_id": bc_id, "short_name": short_name}, actor=actor or "system")
+
+
 def update_bc(bc_id, data, actor="user"):
     """Update an existing BC from a dict of fields. Returns the BC."""
     bc = _get_bc_or_raise(bc_id)

--- a/services/cdisc_api.py
+++ b/services/cdisc_api.py
@@ -15,6 +15,15 @@ logger = logging.getLogger(__name__)
 # services/api_cache.py and is used by all three API clients.
 _cached = cached
 
+# The CDISC Library's general MDR API (Controlled Terminology packages,
+# codelists) lives on a different host/path than the COSMoS-specific base
+# used for BCs/specializations above.
+LIBRARY_BASE_URL = "https://library.cdisc.org/api"
+
+# CDISC SDTM Domain Abbreviation codelist (submissionValue = the 2-8 char
+# domain code, e.g. "LB", "VS", "AE").
+SDTM_DOMAIN_CODELIST = "C66734"
+
 
 def _config_value(name, default=""):
     """Read a config value from the Flask app when a context is active,
@@ -49,6 +58,14 @@ class CDISCApiClient:
     def _get(self, path, params=None):
         url = f"{self.base_url}{path}"
         response = requests.get(url, headers=self.headers, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def _get_library(self, path):
+        """GET against the general CDISC Library MDR API (LIBRARY_BASE_URL),
+        as opposed to the COSMoS-specific base used by _get()."""
+        url = f"{LIBRARY_BASE_URL}{path}"
+        response = requests.get(url, headers=self.headers, timeout=10)
         response.raise_for_status()
         return response.json()
 
@@ -107,6 +124,51 @@ class CDISCApiClient:
                 return [{"error": str(e)}]
 
         return _cached(self._cache_key("dataset_specializations"), _fetch)
+
+    def get_ct_packages(self):
+        """
+        List all Controlled Terminology packages from the CDISC Library
+        (every product family — sdtmct, adamct, cdashct, ... — and every
+        dated version). Returns a list of {href, title, type} link objects.
+        """
+
+        def _fetch():
+            try:
+                data = self._get_library("/mdr/ct/packages")
+                return data.get("_links", {}).get("packages", [])
+            except (requests.RequestException, ValueError) as e:
+                logger.error("CDISC Library CT package list fetch failed: %s", e)
+                return [{"error": str(e)}]
+
+        return _cached(self._cache_key("ct_packages"), _fetch)
+
+    def get_sdtm_domain_codes(self):
+        """
+        Return the SDTM Domain Abbreviation codelist (C66734) terms from the
+        most recent SDTM CT package.
+        Returns a list of {"code": submissionValue, "label": preferredTerm}
+        dicts sorted by code, e.g. [{"code": "AE", "label": "Adverse Event Domain"}, ...].
+        """
+
+        def _fetch():
+            try:
+                packages = self.get_ct_packages()
+                sdtm_packages = sorted(
+                    (p for p in packages if "href" in p and "error" not in p and p["href"].rstrip("/").split("/")[-1].startswith("sdtmct-")),
+                    key=lambda p: p["href"],
+                )
+                if not sdtm_packages:
+                    raise ValueError("No SDTM CT package found in the Library's package list")
+                latest_href = sdtm_packages[-1]["href"]
+                data = self._get_library(f"{latest_href}/codelists/{SDTM_DOMAIN_CODELIST}")
+                codes = [{"code": t["submissionValue"], "label": t.get("preferredTerm", "")} for t in data.get("terms", []) if t.get("submissionValue")]
+                codes.sort(key=lambda c: c["code"])
+                return codes
+            except (requests.RequestException, ValueError) as e:
+                logger.error("CDISC Library SDTM domain codelist fetch failed: %s", e)
+                return [{"error": str(e)}]
+
+        return _cached(self._cache_key("sdtm_domain_codes"), _fetch)
 
     def check_duplicate(self, short_name):
         """

--- a/services/export.py
+++ b/services/export.py
@@ -14,7 +14,26 @@ try:
 except ImportError:
     etree = None
 
+from services.ingestion import VARIABLE_FIELDS
+
 logger = logging.getLogger(__name__)
+
+# Exact header order of the reference file's SDTM_LB/SDTM_VS worksheets
+# (files/BC Examples.xlsx), so an exported specialization sheet is
+# structurally identical to what the ingestion importer produces from a
+# real CDISC-authored workbook — not just importer-parseable. The three
+# *_version/vlm_source columns aren't tracked by DatasetSpecialization and
+# are exported blank; VARIABLE_FIELDS (imported above) supplies the rest.
+SPEC_SHEET_HEADER_FIELDS = [
+    "package_date",
+    "bc_id",
+    "sdtmig_start_version",
+    "sdtmig_end_version",
+    "domain",
+    "vlm_source",
+    "vlm_group_id",
+    "short_name",
+]
 
 
 BC_EXPORT_FIELDS = [
@@ -85,13 +104,19 @@ GOVERNANCE_DEC_FIELDS = ["dec_id", "ncit_dec_code", "dec_label", "data_type", "e
 GOVERNANCE_HEADERS = GOVERNANCE_BC_FIELDS + GOVERNANCE_DEC_FIELDS + ["History of Change"]
 
 
-def export_governance_xlsx(bc_objects):
+def export_governance_xlsx(bc_objects, spec_objects=None):
     """Export BiomedicalConcept ORM objects in BC_LB worksheet format.
 
     Matches the column layout of the BC_LB sheet in the reference file:
     18 columns — BC fields, DEC fields, then History of Change.
     One BC-only row is written per BC, followed by one row per DEC
     (all BC fields repeated on each DEC row).
+
+    When spec_objects (DatasetSpecialization ORM objects) is given, one
+    "SDTM_<domain>" worksheet per domain is added — the same sheet naming
+    and column headers (services.ingestion.SPEC_HEADER_FIELDS +
+    VARIABLE_FIELDS) that services.ingestion.parse_xlsx expects, so the
+    export can be re-imported through the ingestion pipeline unchanged.
     Returns a BytesIO object.
     """
     if openpyxl is None:
@@ -136,6 +161,44 @@ def export_governance_xlsx(bc_objects):
                     val = getattr(dec, header, "") or ""
                 ws.cell(row=row_idx, column=col_idx, value=val)
             row_idx += 1
+
+    if spec_objects:
+        spec_headers = SPEC_SHEET_HEADER_FIELDS + list(VARIABLE_FIELDS)
+
+        specs_by_domain = {}
+        for spec in spec_objects:
+            specs_by_domain.setdefault(spec.domain or "", []).append(spec)
+
+        for domain, specs in specs_by_domain.items():
+            spec_ws = wb.create_sheet(f"SDTM_{domain}"[:31])
+            for col_idx, header in enumerate(spec_headers, start=1):
+                cell = spec_ws.cell(row=1, column=col_idx, value=header)
+                cell.font = header_font_white
+                cell.fill = header_fill
+                cell.alignment = Alignment(horizontal="center")
+
+            row_idx = 2
+            for spec in specs:
+                # sdtmig_start_version/sdtmig_end_version/vlm_source are real
+                # columns in the reference worksheet that this app's model
+                # doesn't track — left blank rather than dropped, so the
+                # exported header row matches the reference file exactly.
+                header_vals = {
+                    "vlm_group_id": spec.vlm_group_id,
+                    "bc_id": spec.bc_id,
+                    "domain": spec.domain or "",
+                    "short_name": spec.short_name or "",
+                    "package_date": "",
+                    "sdtmig_start_version": "",
+                    "sdtmig_end_version": "",
+                    "vlm_source": "",
+                }
+                variables = spec.variables or [{}]
+                for variable in variables:
+                    for col_idx, header in enumerate(spec_headers, start=1):
+                        value = header_vals[header] if header in header_vals else variable.get(header, "")
+                        spec_ws.cell(row=row_idx, column=col_idx, value=value)
+                    row_idx += 1
 
     buf = io.BytesIO()
     wb.save(buf)

--- a/services/governance_service.py
+++ b/services/governance_service.py
@@ -5,56 +5,87 @@ from datetime import datetime, timezone
 
 from extensions import db
 from models.governance import GovernanceRecord
+from models.specialization import DatasetSpecialization
 from services.audit import log_change
-from services.bc_service import _get_bc_or_raise
+from services.bc_service import NotFoundError, _get_bc_or_raise
 
 logger = logging.getLogger(__name__)
 
 STATUS_ORDER = ["provisional", "sme_review", "cdisc_approval", "published"]
 
 
-def advance_governance(bc_id, actor="user", comment=""):
-    """Advance a BC one stage along STATUS_ORDER.
+def _get_spec_or_raise(vlm_group_id):
+    spec = db.session.get(DatasetSpecialization, vlm_group_id)
+    if spec is None:
+        raise NotFoundError(f"Specialization {vlm_group_id!r} not found")
+    return spec
 
-    Returns {"bc_id", "short_name", "status", "advanced"}; advanced is
-    False when the BC is already published (no records written).
+
+def _advance(entity, id_field, id_value, actor, comment):
+    """Advance entity (a BC or DatasetSpecialization) one stage along STATUS_ORDER.
+
+    Writes a GovernanceRecord (bc_id= or vlm_group_id= based on id_field) and
+    an audit log entry. Returns {id_field, "short_name", "status", "advanced"};
+    advanced is False when the entity is already published (no records written).
     """
-    bc = _get_bc_or_raise(bc_id)
-    before_status = bc.status
-    current_idx = STATUS_ORDER.index(bc.status) if bc.status in STATUS_ORDER else 0
+    before_status = entity.status
+    current_idx = STATUS_ORDER.index(entity.status) if entity.status in STATUS_ORDER else 0
     if current_idx >= len(STATUS_ORDER) - 1:
-        return {"bc_id": bc_id, "short_name": bc.short_name, "status": bc.status, "advanced": False}
-    bc.status = STATUS_ORDER[current_idx + 1]
-    bc.updated_at = datetime.now(timezone.utc)
+        return {id_field: id_value, "short_name": entity.short_name, "status": entity.status, "advanced": False}
+    entity.status = STATUS_ORDER[current_idx + 1]
+    entity.updated_at = datetime.now(timezone.utc)
     db.session.add(
         GovernanceRecord(
-            bc_id=bc_id,
+            **{id_field: id_value},
             stage=current_idx + 1,
             action="advanced",
             actor=actor,
             comment=comment or "",
         )
     )
-    log_change("BiomedicalConcept", bc_id, "status_changed", actor=actor, before={"status": before_status}, after={"status": bc.status})
+    log_change(entity.__class__.__name__, id_value, "status_changed", actor=actor, before={"status": before_status}, after={"status": entity.status})
     db.session.commit()
-    return {"bc_id": bc_id, "short_name": bc.short_name, "status": bc.status, "advanced": True}
+    return {id_field: id_value, "short_name": entity.short_name, "status": entity.status, "advanced": True}
 
 
-def reject_bc(bc_id, actor="user", comment=""):
-    """Reject a BC back to provisional (stage 0)."""
-    bc = _get_bc_or_raise(bc_id)
-    before_status = bc.status
-    bc.status = "provisional"
-    bc.updated_at = datetime.now(timezone.utc)
+def _reject(entity, id_field, id_value, actor, comment):
+    """Reject entity (a BC or DatasetSpecialization) back to provisional (stage 0)."""
+    before_status = entity.status
+    entity.status = "provisional"
+    entity.updated_at = datetime.now(timezone.utc)
     db.session.add(
         GovernanceRecord(
-            bc_id=bc_id,
+            **{id_field: id_value},
             stage=0,
             action="rejected",
             actor=actor,
             comment=comment or "",
         )
     )
-    log_change("BiomedicalConcept", bc_id, "rejected", actor=actor, before={"status": before_status}, after={"status": "provisional"})
+    log_change(entity.__class__.__name__, id_value, "rejected", actor=actor, before={"status": before_status}, after={"status": "provisional"})
     db.session.commit()
-    return {"bc_id": bc_id, "short_name": bc.short_name, "status": "provisional", "advanced": False}
+    return {id_field: id_value, "short_name": entity.short_name, "status": "provisional", "advanced": False}
+
+
+def advance_governance(bc_id, actor="user", comment=""):
+    """Advance a BC one stage along STATUS_ORDER."""
+    bc = _get_bc_or_raise(bc_id)
+    return _advance(bc, "bc_id", bc_id, actor, comment)
+
+
+def reject_bc(bc_id, actor="user", comment=""):
+    """Reject a BC back to provisional (stage 0)."""
+    bc = _get_bc_or_raise(bc_id)
+    return _reject(bc, "bc_id", bc_id, actor, comment)
+
+
+def advance_specialization_governance(vlm_group_id, actor="user", comment=""):
+    """Advance a DatasetSpecialization one stage along STATUS_ORDER."""
+    spec = _get_spec_or_raise(vlm_group_id)
+    return _advance(spec, "vlm_group_id", vlm_group_id, actor, comment)
+
+
+def reject_specialization(vlm_group_id, actor="user", comment=""):
+    """Reject a DatasetSpecialization back to provisional (stage 0)."""
+    spec = _get_spec_or_raise(vlm_group_id)
+    return _reject(spec, "vlm_group_id", vlm_group_id, actor, comment)

--- a/services/ingestion.py
+++ b/services/ingestion.py
@@ -27,16 +27,73 @@ FIELD_MAP = {
     "example_set": ["example_set", "examples", "example_values", "values"],
 }
 
+# Spec-level fields (one value per specialization, taken from the first row
+# of its vlm_group_id group).
+_SPEC_HEADER_FIELDS = ("vlm_group_id", "bc_id", "domain", "short_name", "package_date")
+
+# Per-variable fields (one row per SDTM VLM variable, columns I-AF of the
+# SDTM_LB/SDTM_VS worksheets) — every one of these is a real worksheet
+# column, listed in source-column order. Each maps to itself only: with
+# ~24 similarly-named columns in these sheets (e.g. mandatory_variable vs
+# mandatory_value, assigned_term vs assigned_value), fuzzy-matching against
+# a short curated alias list caused silent cross-column overwrites (e.g.
+# assigned_value scoring high enough against sdtm_variable's aliases to
+# clobber the real variable name) — an exact 1:1 map for every column
+# sidesteps that entirely, since a column always scores 1.0 against itself.
+VARIABLE_FIELD_DEFS = (
+    ("sdtm_variable", "Variable"),
+    ("dec_id", "DEC ID"),
+    ("nsv_flag", "NSV Flag"),
+    ("codelist", "Codelist"),
+    ("codelist_submission_value", "Codelist Submission Value"),
+    ("subset_codelist", "Subset Codelist"),
+    ("value_list", "Value List"),
+    ("assigned_term", "Assigned Term"),
+    ("assigned_value", "Assigned Value"),
+    ("role", "Role"),
+    ("subject", "Subject"),
+    ("linking_phrase", "Linking Phrase"),
+    ("predicate_term", "Predicate Term"),
+    ("object", "Object"),
+    ("data_type", "Data Type"),
+    ("length", "Length"),
+    ("format", "Format"),
+    ("significant_digits", "Significant Digits"),
+    ("mandatory_variable", "Mandatory Variable"),
+    ("mandatory_value", "Mandatory Value"),
+    ("origin_type", "Origin Type"),
+    ("origin_source", "Origin Source"),
+    ("comparator", "Comparator"),
+    ("vlm_target", "VLM Target"),
+)
+VARIABLE_FIELDS = tuple(f for f, _ in VARIABLE_FIELD_DEFS)
+
+# Canonical Dataset Specialization field names and aliases. Kept separate
+# from FIELD_MAP (rather than merged) so the wide SDTM VLM sheets don't get
+# force-matched onto unrelated BC/DEC fields by fuzzy similarity.
+#
+# domain holds the actual SDTM domain codelist value (e.g. "LB", "VS"), as
+# stored in the worksheet's own `domain` column — not a literal "SDTM"/
+# "CDASH" toggle.
+SPEC_FIELD_MAP = {
+    "vlm_group_id": ["vlm_group_id", "vlmgroupid", "group_id"],
+    "bc_id": ["bc_id", "bcid", "concept_id"],
+    "domain": ["domain", "sdtm_domain"],
+    "short_name": ["short_name", "shortname", "name"],
+    "package_date": ["package_date", "date", "release_date"],
+    **{field: [field] for field in VARIABLE_FIELDS},
+}
+
 
 def _similarity(a, b):
     return SequenceMatcher(None, a.lower().strip(), b.lower().strip()).ratio()
 
 
-def _match_field(col_name):
+def _match_field(col_name, field_map=FIELD_MAP):
     """Return (canonical_field, confidence) for a column name."""
     col_lower = col_name.lower().replace(" ", "_").replace("-", "_")
     best_field, best_score = None, 0.0
-    for canonical, aliases in FIELD_MAP.items():
+    for canonical, aliases in field_map.items():
         for alias in aliases:
             score = _similarity(col_lower, alias)
             if score > best_score:
@@ -45,9 +102,9 @@ def _match_field(col_name):
     return best_field, round(best_score, 2)
 
 
-def map_fields(raw_dict):
+def map_fields(raw_dict, field_map=FIELD_MAP):
     """
-    Map a raw dict (from any source) to canonical BC field names.
+    Map a raw dict (from any source) to canonical field names.
     Returns (mapped_dict, field_confidences).
     """
     mapped = {}
@@ -55,11 +112,31 @@ def map_fields(raw_dict):
     for col, value in raw_dict.items():
         if value is None or (isinstance(value, float) and str(value) == "nan"):
             continue
-        field, score = _match_field(str(col))
+        field, score = _match_field(str(col), field_map)
         if field and score > 0.5:
             mapped[field] = str(value).strip() if value is not None else ""
             confidences[field] = score
     return mapped, confidences
+
+
+def _detect_record_type(columns, sheet_name=None):
+    """Decide whether a sheet/file holds BC rows or Dataset Specialization rows.
+
+    An explicit BC_/SDTM_/CDASH_ sheet-name prefix is authoritative when
+    present; otherwise fall back to checking for a vlm_group_id column,
+    which is the signature of the specialization VLM export shape.
+    """
+    if sheet_name:
+        upper = sheet_name.upper()
+        if upper.startswith("SDTM_") or upper.startswith("CDASH_"):
+            return "specialization"
+        if upper.startswith("BC_"):
+            return "bc"
+    for col in columns:
+        field, score = _match_field(str(col), SPEC_FIELD_MAP)
+        if field == "vlm_group_id" and score > 0.8:
+            return "specialization"
+    return "bc"
 
 
 def validate_bc(bc_dict):
@@ -78,6 +155,21 @@ def validate_bc(bc_dict):
     ncit = bc_dict.get("ncit_code") or bc_dict.get("bc_id", "")
     if ncit and not ncit.upper().startswith("C"):
         errors.append(f"NCIt code should start with C (got: {ncit})")
+    return errors
+
+
+def validate_specialization(mapped):
+    """
+    Validate a Dataset Specialization dict. Format-only (parse-time) checks —
+    whether bc_id refers to an existing local BC is a runtime concern checked
+    at approval time, not here.
+    Returns list of validation error strings.
+    """
+    errors = []
+    if not mapped.get("vlm_group_id"):
+        errors.append("vlm_group_id is required")
+    if not mapped.get("bc_id"):
+        errors.append("bc_id is required")
     return errors
 
 
@@ -127,6 +219,7 @@ def _group_by_bc(rows, sheet=None):
         errors = validate_bc(mapped)
         results.append(
             {
+                "record_type": "bc",
                 "mapped": mapped,
                 "confidences": g["confidences"],
                 "decs": g["decs"],
@@ -137,23 +230,75 @@ def _group_by_bc(rows, sheet=None):
     return results
 
 
+def _group_by_spec(rows, sheet=None):
+    """
+    Group flat rows (one per SDTM VLM variable) by vlm_group_id.
+    The first row's spec-level fields (bc_id, domain, short_name,
+    package_date) are kept; every row contributes one entry to the
+    resulting record's variables list. domain holds the actual SDTM domain
+    codelist value from the worksheet (e.g. "LB", "VS").
+    Returns a list of merged dicts ready for IngestionRecord creation.
+    """
+    from collections import OrderedDict
+
+    groups = OrderedDict()
+    for mapped, confs in rows:
+        vlm_group_id = mapped.get("vlm_group_id", "")
+        if not vlm_group_id:
+            continue
+        if vlm_group_id not in groups:
+            groups[vlm_group_id] = {"mapped": {}, "confidences": {}, "variables": [], "source_sheet": sheet}
+        g = groups[vlm_group_id]
+        for key in _SPEC_HEADER_FIELDS:
+            if mapped.get(key) and not g["mapped"].get(key):
+                g["mapped"][key] = mapped[key]
+        g["confidences"].update(confs)
+        if mapped.get("sdtm_variable"):
+            g["variables"].append({field: mapped.get(field, "") for field in VARIABLE_FIELDS})
+
+    results = []
+    for vlm_group_id, g in groups.items():
+        mapped = g["mapped"]
+        mapped.setdefault("vlm_group_id", vlm_group_id)
+        mapped.setdefault("domain", "")
+        errors = validate_specialization(mapped)
+        results.append(
+            {
+                "record_type": "specialization",
+                "mapped": mapped,
+                "confidences": g["confidences"],
+                "variables": g["variables"],
+                "errors": errors,
+                "source_sheet": g["source_sheet"],
+            }
+        )
+    return results
+
+
 def parse_xlsx(file_obj):
     """
-    Parse an XLSX file, grouping DEC sub-rows under their parent BC by bc_id.
-    Returns one record per unique BC.
+    Parse an XLSX file. Each sheet is detected as either a BC sheet (DEC
+    sub-rows grouped under their parent by bc_id) or a Dataset Specialization
+    sheet (variable rows grouped under their parent by vlm_group_id).
+    Returns one record per unique BC / specialization.
     """
     results = []
     try:
         xl = pd.ExcelFile(file_obj)
         for sheet in xl.sheet_names:
             df = xl.parse(sheet)
+            record_type = _detect_record_type(df.columns, sheet_name=sheet)
+            field_map = SPEC_FIELD_MAP if record_type == "specialization" else FIELD_MAP
             rows = []
             for _, row in df.iterrows():
                 raw = row.to_dict()
-                mapped, confs = map_fields(raw)
+                mapped, confs = map_fields(raw, field_map)
                 if mapped:
                     rows.append((mapped, confs))
-            results.extend(_group_by_bc(rows, sheet=sheet))
+            if record_type == "specialization":
+                results.extend(_group_by_spec(rows, sheet=sheet))
+            else:
+                results.extend(_group_by_bc(rows, sheet=sheet))
     except Exception as e:
         # Broad by design: user-supplied files can fail in arbitrary ways
         # and the error is surfaced to the review queue via the record.
@@ -163,18 +308,22 @@ def parse_xlsx(file_obj):
 
 
 def parse_csv(file_obj):
-    """Parse a CSV file into BC records."""
+    """Parse a CSV file into BC or Dataset Specialization records (one row each)."""
     results = []
     try:
         df = pd.read_csv(file_obj)
+        record_type = _detect_record_type(df.columns)
+        field_map = SPEC_FIELD_MAP if record_type == "specialization" else FIELD_MAP
+        validate = validate_specialization if record_type == "specialization" else validate_bc
         for _, row in df.iterrows():
             raw = row.to_dict()
-            mapped, confs = map_fields(raw)
+            mapped, confs = map_fields(raw, field_map)
             if not mapped:
                 continue
-            errors = validate_bc(mapped)
+            errors = validate(mapped)
             results.append(
                 {
+                    "record_type": record_type,
                     "raw": {k: str(v) for k, v in raw.items() if v is not None},
                     "mapped": mapped,
                     "confidences": confs,
@@ -189,19 +338,23 @@ def parse_csv(file_obj):
 
 
 def parse_json(file_obj):
-    """Parse a JSON file (array of objects) into BC records."""
+    """Parse a JSON file (array of objects) into BC or Dataset Specialization records."""
     results = []
     try:
         data = json.load(file_obj)
         if isinstance(data, dict):
             data = [data]
+        record_type = _detect_record_type(data[0].keys()) if data else "bc"
+        field_map = SPEC_FIELD_MAP if record_type == "specialization" else FIELD_MAP
+        validate = validate_specialization if record_type == "specialization" else validate_bc
         for item in data:
-            mapped, confs = map_fields(item)
+            mapped, confs = map_fields(item, field_map)
             if not mapped:
                 continue
-            errors = validate_bc(mapped)
+            errors = validate(mapped)
             results.append(
                 {
+                    "record_type": record_type,
                     "raw": {k: str(v) for k, v in item.items()},
                     "mapped": mapped,
                     "confidences": confs,
@@ -215,13 +368,19 @@ def parse_json(file_obj):
     return results
 
 
-def deduplicate(parsed_records, existing_ids):
+def deduplicate(parsed_records, existing_ids, existing_spec_ids=None):
     """
-    Flag records that duplicate existing BC IDs.
+    Flag records that duplicate an existing BC id or specialization vlm_group_id.
     existing_ids: set of bc_id strings already in the library.
+    existing_spec_ids: set of vlm_group_id strings already in the library.
     Returns same list with 'duplicate': True/False added.
     """
+    existing_spec_ids = existing_spec_ids or set()
     for rec in parsed_records:
-        bc_id = rec.get("mapped", {}).get("bc_id") or rec.get("mapped", {}).get("ncit_code", "")
-        rec["duplicate"] = bc_id.upper() in {e.upper() for e in existing_ids}
+        if rec.get("record_type") == "specialization":
+            key = rec.get("mapped", {}).get("vlm_group_id", "")
+            rec["duplicate"] = key.upper() in {e.upper() for e in existing_spec_ids}
+        else:
+            bc_id = rec.get("mapped", {}).get("bc_id") or rec.get("mapped", {}).get("ncit_code", "")
+            rec["duplicate"] = bc_id.upper() in {e.upper() for e in existing_ids}
     return parsed_records

--- a/services/ingestion.py
+++ b/services/ingestion.py
@@ -29,7 +29,7 @@ FIELD_MAP = {
 
 # Spec-level fields (one value per specialization, taken from the first row
 # of its vlm_group_id group).
-_SPEC_HEADER_FIELDS = ("vlm_group_id", "bc_id", "domain", "short_name", "package_date")
+SPEC_HEADER_FIELDS = ("vlm_group_id", "bc_id", "domain", "short_name", "package_date")
 
 # Per-variable fields (one row per SDTM VLM variable, columns I-AF of the
 # SDTM_LB/SDTM_VS worksheets) — every one of these is a real worksheet
@@ -249,7 +249,7 @@ def _group_by_spec(rows, sheet=None):
         if vlm_group_id not in groups:
             groups[vlm_group_id] = {"mapped": {}, "confidences": {}, "variables": [], "source_sheet": sheet}
         g = groups[vlm_group_id]
-        for key in _SPEC_HEADER_FIELDS:
+        for key in SPEC_HEADER_FIELDS:
             if mapped.get(key) and not g["mapped"].get(key):
                 g["mapped"][key] = mapped[key]
         g["confidences"].update(confs)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -327,6 +327,28 @@
   }
 
   /* ─────────────────────────────────────────────
+     Governance board: keep the active BC/Specialization
+     tab in the URL hash so a post-action reload (and
+     any future revisit of the link) restores it instead
+     of always landing back on the first tab.
+  ───────────────────────────────────────────── */
+  function initGovernanceTabs() {
+    const tabButtons = document.querySelectorAll('#governanceTabs button[data-bs-toggle="tab"]');
+    if (!tabButtons.length) return;
+
+    const hashTarget = location.hash && document.querySelector(`#governanceTabs button[data-bs-target="${location.hash}"]`);
+    if (hashTarget && window.bootstrap) {
+      new bootstrap.Tab(hashTarget).show();
+    }
+
+    tabButtons.forEach(function (btn) {
+      btn.addEventListener('shown.bs.tab', function (e) {
+        history.replaceState(null, '', e.target.getAttribute('data-bs-target'));
+      });
+    });
+  }
+
+  /* ─────────────────────────────────────────────
      Kanban: advance / reject via fetch
   ───────────────────────────────────────────── */
   function initKanban() {
@@ -335,15 +357,19 @@
       btn.addEventListener('click', async function (e) {
         e.stopPropagation();
         const bcId = btn.dataset.bcId;
-        if (!bcId) return;
+        const vlmGroupId = btn.dataset.vlmGroupId;
+        if (!bcId && !vlmGroupId) return;
+        const url = vlmGroupId
+          ? `/governance/spec/advance/${encodeURIComponent(vlmGroupId)}`
+          : `/governance/advance/${encodeURIComponent(bcId)}`;
 
         btn.disabled = true;
         try {
-          const resp = await postJson(`/governance/advance/${encodeURIComponent(bcId)}`);
+          const resp = await postJson(url);
           if (resp.ok) {
             location.reload();
           } else {
-            showInlineToast('Could not advance BC — check the audit trail.', 'error');
+            showInlineToast('Could not advance — check the audit trail.', 'error');
             btn.disabled = false;
           }
         } catch (err) {
@@ -359,17 +385,21 @@
       btn.addEventListener('click', async function (e) {
         e.stopPropagation();
         const bcId = btn.dataset.bcId;
-        if (!bcId) return;
+        const vlmGroupId = btn.dataset.vlmGroupId;
+        if (!bcId && !vlmGroupId) return;
+        const url = vlmGroupId
+          ? `/governance/spec/reject/${encodeURIComponent(vlmGroupId)}`
+          : `/governance/reject/${encodeURIComponent(bcId)}`;
 
-        if (!confirm('Reject this BC? This action will be recorded in the audit trail.')) return;
+        if (!confirm('Reject this item? This action will be recorded in the audit trail.')) return;
 
         btn.disabled = true;
         try {
-          const resp = await postJson(`/governance/reject/${encodeURIComponent(bcId)}`);
+          const resp = await postJson(url);
           if (resp.ok) {
             location.reload();
           } else {
-            showInlineToast('Could not reject BC — check the audit trail.', 'error');
+            showInlineToast('Could not reject — check the audit trail.', 'error');
             btn.disabled = false;
           }
         } catch (err) {
@@ -810,6 +840,7 @@
     initNcitLookup();
     initLoincLookup();
     initDecTable();
+    initGovernanceTabs();
     initKanban();
     initAuditDiff();
     initNcitSearch();

--- a/templates/governance.html
+++ b/templates/governance.html
@@ -7,9 +7,26 @@
 <div class="page-header">
   <h1 class="page-title">Governance Workflow Board</h1>
   <span class="page-meta">
-    BCs enter as Provisional and progress through SME Review and CDISC Approval before publishing.
+    BCs and Dataset Specializations enter as Provisional and progress through SME Review and CDISC Approval before publishing.
   </span>
 </div>
+
+<!-- Entity type tabs -->
+<ul class="nav nav-tabs mb-3" id="governanceTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="bc-tab" data-bs-toggle="tab" data-bs-target="#bc-board" type="button" role="tab" aria-controls="bc-board" aria-selected="true">
+      Biomedical Concepts
+    </button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="spec-tab" data-bs-toggle="tab" data-bs-target="#spec-board" type="button" role="tab" aria-controls="spec-board" aria-selected="false">
+      Dataset Specializations
+    </button>
+  </li>
+</ul>
+
+<div class="tab-content" id="governanceTabsContent">
+<div class="tab-pane fade show active" id="bc-board" role="tabpanel" aria-labelledby="bc-tab">
 
 <!-- Summary counts -->
 <div class="metric-grid mb-3">
@@ -187,6 +204,187 @@
 
 </div><!-- /kanban-grid -->
 
+</div><!-- /bc-board -->
+
+<div class="tab-pane fade" id="spec-board" role="tabpanel" aria-labelledby="spec-tab">
+
+<!-- Summary counts -->
+<div class="metric-grid mb-3">
+  <div class="metric-card metric-card-amber">
+    <div class="metric-val metric-val-amber">{{ spec_columns.provisional | length if spec_columns else 0 }}</div>
+    <div class="metric-lbl">Provisional</div>
+  </div>
+  <div class="metric-card metric-card-purple">
+    <div class="metric-val metric-val-purple">{{ spec_columns.sme_review | length if spec_columns else 0 }}</div>
+    <div class="metric-lbl">SME Review</div>
+  </div>
+  <div class="metric-card metric-card-blue">
+    <div class="metric-val metric-val-blue">{{ spec_columns.cdisc_approval | length if spec_columns else 0 }}</div>
+    <div class="metric-lbl">CDISC Approval</div>
+  </div>
+  <div class="metric-card metric-card-green">
+    <div class="metric-val metric-val-green">{{ spec_columns.published | length if spec_columns else 0 }}</div>
+    <div class="metric-lbl">Ready to Publish</div>
+  </div>
+</div>
+
+<!-- Kanban board -->
+<div class="kanban-grid" role="region" aria-label="Specialization governance Kanban board">
+
+  <!-- Provisional column -->
+  <div class="kanban-column" role="list" aria-label="Provisional Specializations">
+    <div class="kanban-column-header kanban-header-provisional">
+      <span>Provisional</span>
+      <span class="kanban-column-count kanban-count-provisional">
+        {{ spec_columns.provisional | length if spec_columns else 0 }}
+      </span>
+    </div>
+    <div class="kanban-column-body">
+      {% if spec_columns and spec_columns.provisional %}
+        {% for spec in spec_columns.provisional %}
+        <div class="kanban-card" role="listitem">
+          <a href="{{ url_for('specializations.detail', vlm_group_id=spec.vlm_group_id) }}" class="text-decoration-none">
+            <div class="kanban-card-title">{{ spec.short_name }}</div>
+          </a>
+          <div class="kanban-card-meta">
+            <code>{{ spec.vlm_group_id }}</code> &middot; {{ spec.domain }}
+            {% if spec.bc %} &middot; {{ spec.bc.short_name }}{% endif %}
+          </div>
+          <span class="bc-badge bc-badge-provisional">Awaiting SME</span>
+          <div class="kanban-card-actions">
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary kanban-advance-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Advance {{ spec.short_name }} to SME Review">
+              <i class="bi bi-arrow-right" aria-hidden="true"></i> Advance
+            </button>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="small text-secondary px-2 py-3 text-center">No specializations in this stage.</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- SME Review column -->
+  <div class="kanban-column" role="list" aria-label="SME Review Specializations">
+    <div class="kanban-column-header kanban-header-sme-review">
+      <span>SME Review</span>
+      <span class="kanban-column-count kanban-count-sme-review">
+        {{ spec_columns.sme_review | length if spec_columns else 0 }}
+      </span>
+    </div>
+    <div class="kanban-column-body">
+      {% if spec_columns and spec_columns.sme_review %}
+        {% for spec in spec_columns.sme_review %}
+        <div class="kanban-card" role="listitem">
+          <a href="{{ url_for('specializations.detail', vlm_group_id=spec.vlm_group_id) }}" class="text-decoration-none">
+            <div class="kanban-card-title">{{ spec.short_name }}</div>
+          </a>
+          <div class="kanban-card-meta">
+            <code>{{ spec.vlm_group_id }}</code> &middot; {{ spec.domain }}
+            {% if spec.bc %} &middot; {{ spec.bc.short_name }}{% endif %}
+          </div>
+          <span class="bc-badge bc-badge-sme-review">SME Review</span>
+          <div class="kanban-card-actions">
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary kanban-advance-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Advance {{ spec.short_name }} to CDISC Approval">
+              <i class="bi bi-arrow-right" aria-hidden="true"></i> Advance
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-danger kanban-reject-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Reject {{ spec.short_name }}">
+              <i class="bi bi-x" aria-hidden="true"></i> Reject
+            </button>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="small text-secondary px-2 py-3 text-center">No specializations in this stage.</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- CDISC Approval column -->
+  <div class="kanban-column" role="list" aria-label="CDISC Approval Specializations">
+    <div class="kanban-column-header kanban-header-cdisc-approval">
+      <span>CDISC Approval</span>
+      <span class="kanban-column-count kanban-count-cdisc-approval">
+        {{ spec_columns.cdisc_approval | length if spec_columns else 0 }}
+      </span>
+    </div>
+    <div class="kanban-column-body">
+      {% if spec_columns and spec_columns.cdisc_approval %}
+        {% for spec in spec_columns.cdisc_approval %}
+        <div class="kanban-card" role="listitem">
+          <a href="{{ url_for('specializations.detail', vlm_group_id=spec.vlm_group_id) }}" class="text-decoration-none">
+            <div class="kanban-card-title">{{ spec.short_name }}</div>
+          </a>
+          <div class="kanban-card-meta">
+            <code>{{ spec.vlm_group_id }}</code> &middot; {{ spec.domain }}
+            {% if spec.bc %} &middot; {{ spec.bc.short_name }}{% endif %}
+          </div>
+          <span class="bc-badge bc-badge-cdisc-approval">CDISC Approval</span>
+          <div class="kanban-card-actions">
+            <button type="button"
+                    class="btn btn-sm btn-outline-success kanban-advance-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Publish {{ spec.short_name }}">
+              <i class="bi bi-check-circle" aria-hidden="true"></i> Publish
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-danger kanban-reject-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Reject {{ spec.short_name }}">
+              <i class="bi bi-x" aria-hidden="true"></i> Reject
+            </button>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="small text-secondary px-2 py-3 text-center">No specializations in this stage.</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Published column -->
+  <div class="kanban-column" role="list" aria-label="Published Specializations">
+    <div class="kanban-column-header kanban-header-published">
+      <span>Ready to Publish</span>
+      <span class="kanban-column-count kanban-count-published">
+        {{ spec_columns.published | length if spec_columns else 0 }}
+      </span>
+    </div>
+    <div class="kanban-column-body">
+      {% if spec_columns and spec_columns.published %}
+        {% for spec in spec_columns.published %}
+        <div class="kanban-card" role="listitem">
+          <a href="{{ url_for('specializations.detail', vlm_group_id=spec.vlm_group_id) }}" class="text-decoration-none">
+            <div class="kanban-card-title">{{ spec.short_name }}</div>
+          </a>
+          <div class="kanban-card-meta">
+            <code>{{ spec.vlm_group_id }}</code> &middot; {{ spec.domain }}
+            {% if spec.bc %} &middot; {{ spec.bc.short_name }}{% endif %}
+          </div>
+          <span class="bc-badge bc-badge-published">Ready to Publish</span>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="small text-secondary px-2 py-3 text-center">No specializations ready for publication yet.</div>
+      {% endif %}
+    </div>
+  </div>
+
+</div><!-- /kanban-grid -->
+
+</div><!-- /spec-board -->
+
+</div><!-- /tab-content -->
+
 <!-- Governance action bar -->
 <div class="bc-card mt-3">
   <div class="bc-card-header">
@@ -203,7 +401,7 @@
       <i class="bi bi-clock-history" aria-hidden="true"></i> View Full Audit Trail
     </a>
     <button type="button" class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#exportModal">
-      <i class="bi bi-download" aria-hidden="true"></i> Export Published BCs
+      <i class="bi bi-download" aria-hidden="true"></i> Export Published Data
     </button>
   </div>
 </div>
@@ -213,7 +411,7 @@
   <div class="modal-dialog modal-sm">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exportModalLabel">Export Published BCs</h5>
+        <h5 class="modal-title" id="exportModalLabel">Export Published Data</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/templates/ingestion.html
+++ b/templates/ingestion.html
@@ -51,12 +51,16 @@
 </div>
 
 {% if queue %}
-<!-- Parsed results table -->
+{% set bc_queue = queue | selectattr('record_type', 'ne', 'specialization') | list %}
+{% set spec_queue = queue | selectattr('record_type', 'equalto', 'specialization') | list %}
+
+<!-- Parsed BC results table -->
+{% if bc_queue %}
 <div class="bc-card">
   <div class="bc-card-header">
     <h2 class="bc-card-title">
-      Parsed Results
-      <span class="bc-badge bc-badge-new ms-2">{{ queue | length }} records</span>
+      Parsed Biomedical Concepts
+      <span class="bc-badge bc-badge-new ms-2">{{ bc_queue | length }} records</span>
     </h2>
     <form method="POST" action="{{ url_for('ingestion.approve_all') }}" class="form-inline">
       <button type="submit" class="btn btn-sm btn-success">
@@ -80,7 +84,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for ir in queue %}
+        {% for ir in bc_queue %}
         {% set m = ir.mapped %}
         <tr>
           <td class="fw-medium">{{ m.short_name or '—' }}</td>
@@ -135,6 +139,93 @@
     </table>
   </div>
 </div>
+{% endif %}
+
+<!-- Parsed Dataset Specialization results table -->
+{% if spec_queue %}
+<div class="bc-card">
+  <div class="bc-card-header">
+    <h2 class="bc-card-title">
+      Parsed Dataset Specializations
+      <span class="bc-badge bc-badge-new ms-2">{{ spec_queue | length }} records</span>
+    </h2>
+    {% if not bc_queue %}
+    <form method="POST" action="{{ url_for('ingestion.approve_all') }}" class="form-inline">
+      <button type="submit" class="btn btn-sm btn-success">
+        <i class="bi bi-check-all"></i> Approve All Valid
+      </button>
+    </form>
+    {% endif %}
+  </div>
+  <p class="small text-secondary px-3">
+    A specialization can only be approved once its Biomedical Concept exists locally —
+    approve the matching BC first if it's still pending above.
+  </p>
+
+  <div class="table-responsive">
+    <table class="bc-table" aria-label="Parsed Dataset Specialization results">
+      <thead>
+        <tr>
+          <th scope="col">VLM Group ID</th>
+          <th scope="col">BC ID</th>
+          <th scope="col">Domain</th>
+          <th scope="col">Short Name</th>
+          <th scope="col">Sheet</th>
+          <th scope="col">Variables</th>
+          <th scope="col">Validation</th>
+          <th scope="col">Dup?</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for ir in spec_queue %}
+        {% set m = ir.mapped %}
+        <tr>
+          <td><code>{{ m.vlm_group_id or '—' }}</code></td>
+          <td><code>{{ m.bc_id or '—' }}</code></td>
+          <td>{{ m.domain or '—' }}</td>
+          <td class="fw-medium">{{ m.short_name or '—' }}</td>
+          <td><small class="text-secondary">{{ ir.source_sheet or '—' }}</small></td>
+          <td class="text-secondary small">{{ ir.decs | length }} variable{{ 's' if ir.decs | length != 1 else '' }}</td>
+          <td>
+            {% if ir.errors %}
+              <span class="bc-badge bc-badge-conflict" title="{{ ir.errors | join(', ') }}">
+                <i class="bi bi-x-circle"></i> {{ ir.errors | length }} error(s)
+              </span>
+            {% else %}
+              <span class="bc-badge bc-badge-published">
+                <i class="bi bi-check-circle"></i> Valid
+              </span>
+            {% endif %}
+          </td>
+          <td>
+            {% if ir.duplicate %}
+              <span class="bc-badge bc-badge-provisional">Dup</span>
+            {% else %}
+              <span class="text-secondary">—</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class="d-flex gap-1">
+              <form method="POST" action="{{ url_for('ingestion.approve', record_id=ir.id) }}" class="form-inline">
+                <button type="submit" class="btn btn-sm btn-outline-success">
+                  <i class="bi bi-check"></i> Approve
+                </button>
+              </form>
+              <form method="POST" action="{{ url_for('ingestion.reject', record_id=ir.id) }}" class="form-inline">
+                <button type="submit" class="btn btn-sm btn-outline-danger">
+                  <i class="bi bi-x"></i> Reject
+                </button>
+              </form>
+            </div>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
 {% endif %}
 
 {% endblock %}

--- a/templates/specializations.html
+++ b/templates/specializations.html
@@ -170,6 +170,7 @@
           <th scope="col">Domain</th>
           <th scope="col">Short Name</th>
           <th scope="col">Variables</th>
+          <th scope="col">Status</th>
           <th scope="col">Actions</th>
         </tr>
       </thead>
@@ -189,6 +190,12 @@
           <td class="text-secondary small">
             {% set vcount = spec.variables | length %}
             {{ vcount }} variable{{ 's' if vcount != 1 else '' }}
+          </td>
+          <td>
+            {% set status_labels = {"provisional": "Provisional", "sme_review": "SME Review", "cdisc_approval": "CDISC Approval", "published": "Published"} %}
+            <span class="bc-badge bc-badge-{{ (spec.status or 'provisional') | replace('_', '-') }}">
+              {{ status_labels.get(spec.status, (spec.status or 'provisional') | replace('_', ' ') | title) }}
+            </span>
           </td>
           <td>
             <div class="d-flex gap-1">

--- a/templates/specializations.html
+++ b/templates/specializations.html
@@ -16,8 +16,8 @@
   </div>
 </div>
 
-<!-- Add specialization form (collapsed by default) -->
-<div class="collapse mb-3" id="specialization-form-panel">
+<!-- Add specialization form (collapsed by default, expanded when editing) -->
+<div class="collapse mb-3 {% if edit_spec %}show{% endif %}" id="specialization-form-panel">
   <div class="bc-card">
     <div class="bc-card-header">
       <h2 class="bc-card-title">
@@ -72,21 +72,19 @@
         </div>
 
         <div class="col-md-3">
-          <fieldset>
-            <legend class="form-label small fw-semibold">Domain <span class="text-danger" aria-hidden="true">*</span></legend>
-            <div class="d-flex gap-3">
-              <div class="form-check">
-                <input class="form-check-input" type="radio" name="domain" id="domain-sdtm" value="SDTM"
-                       {% if not edit_spec or edit_spec.domain == 'SDTM' %}checked{% endif %}>
-                <label class="form-check-label small" for="domain-sdtm">SDTM</label>
-              </div>
-              <div class="form-check">
-                <input class="form-check-input" type="radio" name="domain" id="domain-cdash" value="CDASH"
-                       {% if edit_spec and edit_spec.domain == 'CDASH' %}checked{% endif %}>
-                <label class="form-check-label small" for="domain-cdash">CDASH</label>
-              </div>
-            </div>
-          </fieldset>
+          <label for="spec_domain" class="form-label small fw-semibold">Domain <span class="text-danger" aria-hidden="true">*</span></label>
+          <select id="spec_domain" name="domain" class="form-select form-select-sm" required
+                  aria-label="Select an SDTM domain">
+            <option value="">— Select Domain —</option>
+            {% for d in domain_codes if d.code %}
+            <option value="{{ d.code }}" {% if edit_spec and edit_spec.domain == d.code %}selected{% endif %}>
+              {{ d.code }} — {{ d.label }}
+            </option>
+            {% endfor %}
+            {% if edit_spec and edit_spec.domain and edit_spec.domain not in (domain_codes | map(attribute='code') | list) %}
+            <option value="{{ edit_spec.domain }}" selected>{{ edit_spec.domain }} (not in current SDTM CT)</option>
+            {% endif %}
+          </select>
         </div>
 
         <div class="col-md-4">
@@ -97,51 +95,33 @@
         </div>
       </div>
 
-      <!-- Variables table -->
+      <!-- Variables table: one column per SDTM VLM worksheet field (I-AF) -->
       <h3 class="form-section-title">Variables</h3>
       <div class="table-responsive mb-3">
         <table class="dec-table" aria-label="Specialization variables">
           <thead>
             <tr>
-              <th scope="col">Variable Name</th>
-              <th scope="col">Label</th>
-              <th scope="col">Data Type</th>
-              <th scope="col" class="text-center">Required</th>
+              {% for field, label in variable_field_defs %}
+              <th scope="col">{{ label }}</th>
+              {% endfor %}
               <th scope="col" style="width: 40px;"></th>
             </tr>
           </thead>
-          <tbody id="spec-variables-body" data-row-count="{{ (edit_spec.variables | length) if edit_spec and edit_spec.variables else 0 }}">
+          <tbody id="spec-variables-body"
+                 data-row-count="{{ (edit_spec.variables | length) if edit_spec and edit_spec.variables else 0 }}"
+                 data-fields='{{ variable_field_defs | map(attribute=0) | list | tojson }}'>
             {% if edit_spec and edit_spec.variables %}
               {% for var in edit_spec.variables %}
+              {% set row_idx = loop.index0 %}
               <tr>
+                {% for field, label in variable_field_defs %}
                 <td>
                   <input type="text" class="form-control form-control-sm"
-                         name="variables[{{ loop.index0 }}][name]"
-                         value="{{ var.name }}"
-                         placeholder="e.g. LBTESTCD" aria-label="Variable name">
+                         name="variables[{{ row_idx }}][{{ field }}]"
+                         value="{{ var[field] }}"
+                         aria-label="{{ label }}">
                 </td>
-                <td>
-                  <input type="text" class="form-control form-control-sm"
-                         name="variables[{{ loop.index0 }}][label]"
-                         value="{{ var.label }}"
-                         placeholder="e.g. Lab Test Short Name" aria-label="Variable label">
-                </td>
-                <td>
-                  <select class="form-select form-select-sm"
-                          name="variables[{{ loop.index0 }}][data_type]"
-                          aria-label="Data type">
-                    {% for dtype in ['string','decimal','integer','boolean','date','datetime'] %}
-                      <option value="{{ dtype }}" {% if var.data_type == dtype %}selected{% endif %}>{{ dtype }}</option>
-                    {% endfor %}
-                  </select>
-                </td>
-                <td class="text-center">
-                  <input type="checkbox" class="form-check-input"
-                         name="variables[{{ loop.index0 }}][required]"
-                         value="1"
-                         {% if var.required %}checked{% endif %}
-                         aria-label="Required">
-                </td>
+                {% endfor %}
                 <td>
                   <button type="button" class="btn btn-sm btn-outline-danger spec-var-delete-btn"
                           aria-label="Delete variable row">
@@ -199,17 +179,16 @@
           <td><code>{{ spec.vlm_group_id | default('—') }}</code></td>
           <td class="fw-medium">
             <a href="{{ url_for('bc.detail', bc_id=spec.bc_id) }}" class="text-decoration-none">
-              {{ spec.bc_name | default(spec.bc_id) }}
+              {{ spec.bc.short_name if spec.bc else spec.bc_id }}
             </a>
           </td>
           <td>
-            <span class="bc-badge {% if spec.domain == 'SDTM' %}bc-badge-cdisc-approval{% else %}bc-badge-sme-review{% endif %}">
-              {{ spec.domain }}
-            </span>
+            <span class="bc-badge bc-badge-cdisc-approval">{{ spec.domain }}</span>
           </td>
           <td>{{ spec.short_name }}</td>
           <td class="text-secondary small">
-            {{ spec.variable_count | default(0) }} variable{{ 's' if spec.variable_count != 1 else '' }}
+            {% set vcount = spec.variables | length %}
+            {{ vcount }} variable{{ 's' if vcount != 1 else '' }}
           </td>
           <td>
             <div class="d-flex gap-1">
@@ -268,51 +247,41 @@
     });
   }
 
-  // Initialize variable row counter from server-rendered data
-  let varRowIndex = parseInt(document.getElementById('spec-variables-body').dataset.rowCount || '0', 10);
+  // Variable rows are built generically from the field list the server
+  // rendered the table header from, so JS never hand-duplicates the ~24
+  // SDTM VLM column names.
+  const varBody = document.getElementById('spec-variables-body');
+  const varFields = varBody ? JSON.parse(varBody.dataset.fields || '[]') : [];
+  let varRowIndex = varBody ? parseInt(varBody.dataset.rowCount || '0', 10) : 0;
+
+  function escapeAttr(value) {
+    return String(value == null ? '' : value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  }
+
+  function buildVariableRow(rowIndex, values) {
+    values = values || {};
+    const cells = varFields.map(function (field) {
+      return `<td><input type="text" class="form-control form-control-sm"
+                     name="variables[${rowIndex}][${field}]"
+                     value="${escapeAttr(values[field])}" aria-label="${field}"></td>`;
+    }).join('');
+    const tr = document.createElement('tr');
+    tr.innerHTML = cells + `
+      <td>
+        <button type="button" class="btn btn-sm btn-outline-danger spec-var-delete-btn"
+                aria-label="Delete variable row">
+          <i class="bi bi-trash" aria-hidden="true"></i>
+        </button>
+      </td>
+    `;
+    return tr;
+  }
 
   // Add variable row
   const addVarBtn = document.getElementById('add-spec-var-btn');
-  const varBody = document.getElementById('spec-variables-body');
   if (addVarBtn && varBody) {
     addVarBtn.addEventListener('click', function () {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td>
-          <input type="text" class="form-control form-control-sm"
-                 name="variables[${varRowIndex}][name]"
-                 placeholder="e.g. LBTESTCD" aria-label="Variable name">
-        </td>
-        <td>
-          <input type="text" class="form-control form-control-sm"
-                 name="variables[${varRowIndex}][label]"
-                 placeholder="e.g. Lab Test Short Name" aria-label="Variable label">
-        </td>
-        <td>
-          <select class="form-select form-select-sm"
-                  name="variables[${varRowIndex}][data_type]"
-                  aria-label="Data type">
-            <option value="string">string</option>
-            <option value="decimal">decimal</option>
-            <option value="integer">integer</option>
-            <option value="boolean">boolean</option>
-            <option value="date">date</option>
-            <option value="datetime">datetime</option>
-          </select>
-        </td>
-        <td class="text-center">
-          <input type="checkbox" class="form-check-input"
-                 name="variables[${varRowIndex}][required]"
-                 value="1" aria-label="Required">
-        </td>
-        <td>
-          <button type="button" class="btn btn-sm btn-outline-danger spec-var-delete-btn"
-                  aria-label="Delete variable row">
-            <i class="bi bi-trash" aria-hidden="true"></i>
-          </button>
-        </td>
-      `;
-      varBody.appendChild(tr);
+      varBody.appendChild(buildVariableRow(varRowIndex));
       varRowIndex++;
     });
   }
@@ -330,7 +299,7 @@
   if (generateBtn) {
     generateBtn.addEventListener('click', async function () {
       const bcId = document.getElementById('bc_selector').value;
-      const domain = document.querySelector('input[name="domain"]:checked');
+      const domain = document.getElementById('spec_domain').value;
       if (!bcId || !domain) {
         alert('Please select a BC and domain before generating from templates.');
         return;
@@ -343,7 +312,7 @@
         const resp = await fetch('/specializations/generate-from-dec', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ bc_id: bcId, domain: domain.value })
+          body: JSON.stringify({ bc_id: bcId, domain: domain })
         });
 
         if (!resp.ok) throw new Error('Generation failed');
@@ -353,30 +322,7 @@
           varBody.innerHTML = '';
           varRowIndex = 0;
           data.variables.forEach(function (v) {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
-              <td><input type="text" class="form-control form-control-sm"
-                         name="variables[${varRowIndex}][name]" value="${v.name || ''}" aria-label="Variable name"></td>
-              <td><input type="text" class="form-control form-control-sm"
-                         name="variables[${varRowIndex}][label]" value="${v.label || ''}" aria-label="Variable label"></td>
-              <td>
-                <select class="form-select form-select-sm" name="variables[${varRowIndex}][data_type]" aria-label="Data type">
-                  ${['string','decimal','integer','boolean','date','datetime'].map(function(dt) {
-                    return `<option value="${dt}" ${v.data_type === dt ? 'selected' : ''}>${dt}</option>`;
-                  }).join('')}
-                </select>
-              </td>
-              <td class="text-center">
-                <input type="checkbox" class="form-check-input" name="variables[${varRowIndex}][required]"
-                       value="1" ${v.required ? 'checked' : ''} aria-label="Required">
-              </td>
-              <td>
-                <button type="button" class="btn btn-sm btn-outline-danger spec-var-delete-btn" aria-label="Delete variable row">
-                  <i class="bi bi-trash" aria-hidden="true"></i>
-                </button>
-              </td>
-            `;
-            varBody.appendChild(tr);
+            varBody.appendChild(buildVariableRow(varRowIndex, v));
             varRowIndex++;
           });
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from models.audit import AuditLog  # noqa: F401  (registers table metadata)
 from models.bc import BiomedicalConcept, DataElementConcept  # noqa: F401
 from models.governance import GovernanceRecord  # noqa: F401
 from models.ingestion import IngestionRecord  # noqa: F401
+from models.specialization import DatasetSpecialization  # noqa: F401
 
 
 class TestConfig:
@@ -66,3 +67,19 @@ def sample_bc(app):
         _db.session.add(bc)
         _db.session.commit()
         return bc.bc_id  # return PK so tests can re-query within their own context
+
+
+@pytest.fixture()
+def sample_spec(app, sample_bc):
+    """A minimal DatasetSpecialization persisted to the test DB, linked to sample_bc."""
+    with app.app_context():
+        spec = DatasetSpecialization(
+            vlm_group_id="C12345.SDTM",
+            bc_id=sample_bc,
+            domain="VS",
+            short_name="Test Spec",
+            status="provisional",
+        )
+        _db.session.add(spec)
+        _db.session.commit()
+        return spec.vlm_group_id  # return PK so tests can re-query within their own context

--- a/tests/test_bc_service.py
+++ b/tests/test_bc_service.py
@@ -1,0 +1,35 @@
+"""Tests for services/bc_service.py — write operations shared by routes/MCP."""
+
+from extensions import db
+from models.audit import AuditLog
+from models.bc import BiomedicalConcept
+from services.bc_service import get_or_create_bc_stub
+
+
+class TestGetOrCreateBcStub:
+    def test_creates_stub_when_missing(self, app):
+        with app.app_context():
+            bc = get_or_create_bc_stub("C999", short_name="New Concept", actor="user")
+            assert bc.bc_id == "C999"
+            assert bc.short_name == "New Concept"
+            assert bc.status == "provisional"
+            assert db.session.get(BiomedicalConcept, "C999") is not None
+
+    def test_returns_existing_bc_unchanged(self, app, sample_bc):
+        with app.app_context():
+            bc = get_or_create_bc_stub(sample_bc, short_name="Ignored Name")
+            assert bc.bc_id == sample_bc
+            assert bc.short_name == "Test Concept"
+
+    def test_writes_audit_log_on_create(self, app):
+        with app.app_context():
+            get_or_create_bc_stub("C999", short_name="New Concept", actor="user")
+            log = AuditLog.query.filter_by(entity_type="BiomedicalConcept", entity_id="C999", action="created").first()
+            assert log is not None
+
+    def test_no_audit_log_when_already_exists(self, app, sample_bc):
+        with app.app_context():
+            AuditLog.query.delete()
+            db.session.commit()
+            get_or_create_bc_stub(sample_bc, short_name="Ignored Name")
+            assert AuditLog.query.count() == 0

--- a/tests/test_cdisc_api_cache.py
+++ b/tests/test_cdisc_api_cache.py
@@ -118,3 +118,99 @@ class TestClientCacheKeys:
         with app.app_context():
             result = CDISCApiClient().get_biomedical_concepts()
         assert result == [{"href": "/x", "title": "X"}]
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+PACKAGES_PAYLOAD = {
+    "_links": {
+        "packages": [
+            {"href": "/mdr/ct/packages/adamct-2025-09-26", "title": "ADaM CT", "type": "Terminology"},
+            {"href": "/mdr/ct/packages/sdtmct-2024-09-27", "title": "SDTM CT 2024-09-27", "type": "Terminology"},
+            {"href": "/mdr/ct/packages/sdtmct-2025-09-26", "title": "SDTM CT 2025-09-26", "type": "Terminology"},
+        ]
+    }
+}
+
+CODELIST_PAYLOAD = {
+    "conceptId": "C66734",
+    "name": "SDTM Domain Abbreviation",
+    "terms": [
+        {"conceptId": "C49562", "submissionValue": "AE", "preferredTerm": "Adverse Event Domain"},
+        {"conceptId": "C66741", "submissionValue": "VS", "preferredTerm": "Vital Signs Domain"},
+    ],
+}
+
+
+class TestGetCtPackages:
+    def setup_method(self):
+        cdisc_api._cache.clear()
+
+    def test_returns_package_links(self, app, monkeypatch):
+        monkeypatch.setattr(cdisc_api.requests, "get", lambda *a, **kw: _FakeResp(PACKAGES_PAYLOAD))
+        with app.app_context():
+            result = CDISCApiClient().get_ct_packages()
+        assert len(result) == 3
+        assert result[0]["href"] == "/mdr/ct/packages/adamct-2025-09-26"
+
+    def test_error_encoded_not_raised(self, app, monkeypatch):
+        import requests
+
+        def boom(*a, **kw):
+            raise requests.ConnectionError("no network")
+
+        monkeypatch.setattr(cdisc_api.requests, "get", boom)
+        with app.app_context():
+            result = CDISCApiClient().get_ct_packages()
+        assert "error" in result[0]
+
+
+class TestGetSdtmDomainCodes:
+    def setup_method(self):
+        cdisc_api._cache.clear()
+
+    def test_uses_most_recent_sdtm_package(self, app, monkeypatch):
+        requested_urls = []
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            requested_urls.append(url)
+            if url.endswith("/mdr/ct/packages"):
+                return _FakeResp(PACKAGES_PAYLOAD)
+            return _FakeResp(CODELIST_PAYLOAD)
+
+        monkeypatch.setattr(cdisc_api.requests, "get", fake_get)
+        with app.app_context():
+            result = CDISCApiClient().get_sdtm_domain_codes()
+
+        assert any(u.endswith("/mdr/ct/packages/sdtmct-2025-09-26/codelists/C66734") for u in requested_urls)
+        assert result == [
+            {"code": "AE", "label": "Adverse Event Domain"},
+            {"code": "VS", "label": "Vital Signs Domain"},
+        ]
+
+    def test_no_sdtm_package_found_returns_error(self, app, monkeypatch):
+        empty_payload = {"_links": {"packages": [{"href": "/mdr/ct/packages/adamct-2025-09-26", "title": "ADaM CT"}]}}
+        monkeypatch.setattr(cdisc_api.requests, "get", lambda *a, **kw: _FakeResp(empty_payload))
+        with app.app_context():
+            result = CDISCApiClient().get_sdtm_domain_codes()
+        assert "error" in result[0]
+
+    def test_network_failure_encoded_not_raised(self, app, monkeypatch):
+        import requests
+
+        def boom(*a, **kw):
+            raise requests.ConnectionError("no network")
+
+        monkeypatch.setattr(cdisc_api.requests, "get", boom)
+        with app.app_context():
+            result = CDISCApiClient().get_sdtm_domain_codes()
+        assert "error" in result[0]

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -7,6 +7,7 @@ from lxml import etree
 
 from extensions import db
 from models.bc import BiomedicalConcept, DataElementConcept
+from models.specialization import DatasetSpecialization
 from services.export import (
     BC_EXPORT_FIELDS,
     GOVERNANCE_HEADERS,
@@ -15,6 +16,7 @@ from services.export import (
     export_odm_xml,
     export_xlsx,
 )
+from services.ingestion import VARIABLE_FIELDS, parse_xlsx
 
 SAMPLE_BCS = [
     {
@@ -178,6 +180,110 @@ class TestExportGovernanceXlsx:
         system_name_col = GOVERNANCE_HEADERS.index("system_name") + 1
         assert ws.cell(row=2, column=system_col).value in ("", None)
         assert ws.cell(row=2, column=system_name_col).value in ("", None)
+
+
+class TestExportGovernanceXlsxSpecializations:
+    def _make_bc(self, bc_id="C64854"):
+        bc = BiomedicalConcept(bc_id=bc_id, short_name="Ketone Concentration in Urine", status="published")
+        db.session.add(bc)
+        db.session.commit()
+        return bc
+
+    def test_no_specializations_produces_no_extra_sheets(self, app):
+        with app.app_context():
+            self._make_bc()
+            wb = openpyxl.load_workbook(export_governance_xlsx([], []))
+        assert wb.sheetnames == ["BC_LB"]
+
+    def test_specializations_grouped_by_domain_into_sdtm_sheets(self, app):
+        with app.app_context():
+            bc = self._make_bc()
+            db.session.add_all(
+                [
+                    DatasetSpecialization(vlm_group_id="C64854.LB", bc_id=bc.bc_id, domain="LB", short_name="Ketones LB", status="published"),
+                    DatasetSpecialization(vlm_group_id="C64854.VS", bc_id=bc.bc_id, domain="VS", short_name="Ketones VS", status="published"),
+                ]
+            )
+            db.session.commit()
+            specs = DatasetSpecialization.query.order_by(DatasetSpecialization.vlm_group_id).all()
+            wb = openpyxl.load_workbook(export_governance_xlsx([], specs))
+        assert "SDTM_LB" in wb.sheetnames
+        assert "SDTM_VS" in wb.sheetnames
+
+    def test_sheet_headers_match_import_expectations(self, app):
+        with app.app_context():
+            bc = self._make_bc()
+            spec = DatasetSpecialization(vlm_group_id="C64854.LB", bc_id=bc.bc_id, domain="LB", short_name="Ketones LB", status="published")
+            db.session.add(spec)
+            db.session.commit()
+            wb = openpyxl.load_workbook(export_governance_xlsx([], [spec]))
+        ws = wb["SDTM_LB"]
+        headers = [c.value for c in ws[1]]
+        # Exact header row from the reference file's SDTM_LB/SDTM_VS sheets
+        # (files/BC Examples.xlsx) — order matters here, not just column
+        # membership, since the goal is a byte-for-byte-comparable header.
+        assert headers == [
+            "package_date",
+            "bc_id",
+            "sdtmig_start_version",
+            "sdtmig_end_version",
+            "domain",
+            "vlm_source",
+            "vlm_group_id",
+            "short_name",
+        ] + list(VARIABLE_FIELDS)
+
+    def test_one_row_per_variable_with_header_fields_repeated(self, app):
+        with app.app_context():
+            bc = self._make_bc()
+            spec = DatasetSpecialization(vlm_group_id="C64854.LB", bc_id=bc.bc_id, domain="LB", short_name="Ketones LB", status="published")
+            spec.variables = [
+                {"sdtm_variable": "LBTESTCD", "data_type": "string"},
+                {"sdtm_variable": "LBORRES", "data_type": "decimal"},
+            ]
+            db.session.add(spec)
+            db.session.commit()
+            wb = openpyxl.load_workbook(export_governance_xlsx([], [spec]))
+        ws = wb["SDTM_LB"]
+        headers = [c.value for c in ws[1]]
+        vlm_col = headers.index("vlm_group_id") + 1
+        var_col = headers.index("sdtm_variable") + 1
+        assert ws.cell(row=2, column=vlm_col).value == "C64854.LB"
+        assert ws.cell(row=2, column=var_col).value == "LBTESTCD"
+        assert ws.cell(row=3, column=vlm_col).value == "C64854.LB"
+        assert ws.cell(row=3, column=var_col).value == "LBORRES"
+
+    def test_specialization_with_no_variables_still_exports_header_row(self, app):
+        with app.app_context():
+            bc = self._make_bc()
+            spec = DatasetSpecialization(vlm_group_id="C64854.LB", bc_id=bc.bc_id, domain="LB", short_name="Ketones LB", status="published")
+            db.session.add(spec)
+            db.session.commit()
+            wb = openpyxl.load_workbook(export_governance_xlsx([], [spec]))
+        ws = wb["SDTM_LB"]
+        assert ws.max_row == 2
+        headers = [c.value for c in ws[1]]
+        assert ws.cell(row=2, column=headers.index("vlm_group_id") + 1).value == "C64854.LB"
+
+    def test_export_round_trips_through_ingestion_parser(self, app):
+        with app.app_context():
+            bc = self._make_bc()
+            spec = DatasetSpecialization(vlm_group_id="C64854.LB", bc_id=bc.bc_id, domain="LB", short_name="Ketones LB", status="published")
+            spec.variables = [{"sdtm_variable": "LBTESTCD", "data_type": "string", "mandatory_variable": "Y"}]
+            db.session.add(spec)
+            db.session.commit()
+            buf = export_governance_xlsx([], [spec])
+
+        records = parse_xlsx(buf)
+        spec_records = [r for r in records if r.get("record_type") == "specialization"]
+        assert len(spec_records) == 1
+        rec = spec_records[0]
+        assert rec["mapped"]["vlm_group_id"] == "C64854.LB"
+        assert rec["mapped"]["bc_id"] == "C64854"
+        assert rec["mapped"]["domain"] == "LB"
+        assert rec["variables"][0]["sdtm_variable"] == "LBTESTCD"
+        assert rec["variables"][0]["mandatory_variable"] == "Y"
+        assert rec["errors"] == []
 
 
 class TestExportOdmXml:

--- a/tests/test_governance_routes.py
+++ b/tests/test_governance_routes.py
@@ -1,9 +1,13 @@
 """Tests for routes/governance.py — Kanban advance and reject."""
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from extensions import db
 from models.audit import AuditLog
 from models.bc import BiomedicalConcept
 from models.governance import GovernanceRecord
+from models.specialization import DatasetSpecialization
 
 STATUS_ORDER = ["provisional", "sme_review", "cdisc_approval", "published"]
 
@@ -234,3 +238,108 @@ class TestGovernanceExport:
         code_col = headers.index("code") + 1
         data_row = ws.cell(row=2, column=code_col).value
         assert data_row == "12345-6"
+
+
+class TestSpecAdvance:
+    def test_advances_provisional_to_sme_review(self, client, app, sample_spec):
+        client.post(f"/governance/spec/advance/{sample_spec}")
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            assert spec.status == "sme_review"
+
+    def test_advance_through_all_stages(self, client, app, sample_spec):
+        for _ in range(3):
+            client.post(f"/governance/spec/advance/{sample_spec}")
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            assert spec.status == "published"
+
+    def test_already_published_stays_published(self, client, app, sample_spec):
+        for _ in range(3):
+            client.post(f"/governance/spec/advance/{sample_spec}")
+        r = client.post(f"/governance/spec/advance/{sample_spec}", follow_redirects=True)
+        assert r.status_code == 200
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            assert spec.status == "published"
+
+    def test_advance_creates_governance_record(self, client, app, sample_spec):
+        client.post(f"/governance/spec/advance/{sample_spec}")
+        with app.app_context():
+            rec = GovernanceRecord.query.filter_by(vlm_group_id=sample_spec, action="advanced").first()
+            assert rec is not None
+            assert rec.bc_id is None
+
+    def test_advance_writes_audit_log(self, client, app, sample_spec):
+        client.post(f"/governance/spec/advance/{sample_spec}")
+        with app.app_context():
+            log = AuditLog.query.filter_by(entity_id=sample_spec, action="status_changed").first()
+            assert log is not None
+            assert log.before_state == {"status": "provisional"}
+            assert log.after_state == {"status": "sme_review"}
+
+    def test_advance_nonexistent_spec_returns_404(self, client):
+        r = client.post("/governance/spec/advance/NOPE")
+        assert r.status_code == 404
+
+    def test_advance_ajax_returns_json(self, client, sample_spec):
+        r = client.post(
+            f"/governance/spec/advance/{sample_spec}",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["status"] == "sme_review"
+        assert data["vlm_group_id"] == sample_spec
+
+
+class TestSpecReject:
+    def test_reject_returns_to_provisional(self, client, app, sample_spec):
+        client.post(f"/governance/spec/advance/{sample_spec}")
+        client.post(f"/governance/spec/reject/{sample_spec}")
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            assert spec.status == "provisional"
+
+    def test_reject_creates_governance_record(self, client, app, sample_spec):
+        client.post(f"/governance/spec/reject/{sample_spec}")
+        with app.app_context():
+            rec = GovernanceRecord.query.filter_by(vlm_group_id=sample_spec, action="rejected").first()
+            assert rec is not None
+
+    def test_reject_writes_audit_log(self, client, app, sample_spec):
+        client.post(f"/governance/spec/advance/{sample_spec}")
+        client.post(f"/governance/spec/reject/{sample_spec}")
+        with app.app_context():
+            log = AuditLog.query.filter_by(entity_id=sample_spec, action="rejected").first()
+            assert log is not None
+            assert log.after_state == {"status": "provisional"}
+
+    def test_reject_ajax_returns_json(self, client, sample_spec):
+        r = client.post(
+            f"/governance/spec/reject/{sample_spec}",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["status"] == "provisional"
+
+    def test_reject_nonexistent_spec_returns_404(self, client):
+        r = client.post("/governance/spec/reject/NOPE")
+        assert r.status_code == 404
+
+
+class TestGovernanceRecordOneEntityConstraint:
+    def test_both_bc_id_and_vlm_group_id_set_raises(self, app, sample_spec):
+        with app.app_context():
+            db.session.add(GovernanceRecord(bc_id="C12345", vlm_group_id=sample_spec, stage=0, action="advanced"))
+            with pytest.raises(IntegrityError):
+                db.session.commit()
+            db.session.rollback()
+
+    def test_neither_bc_id_nor_vlm_group_id_set_raises(self, app):
+        with app.app_context():
+            db.session.add(GovernanceRecord(stage=0, action="advanced"))
+            with pytest.raises(IntegrityError):
+                db.session.commit()
+            db.session.rollback()

--- a/tests/test_ingestion_routes.py
+++ b/tests/test_ingestion_routes.py
@@ -8,6 +8,7 @@ from extensions import db
 from models.audit import AuditLog
 from models.bc import BiomedicalConcept
 from models.ingestion import IngestionRecord
+from models.specialization import DatasetSpecialization
 
 
 def _csv_file(rows):
@@ -21,6 +22,18 @@ def _csv_file(rows):
 
 def _json_file(data):
     return (io.BytesIO(json.dumps(data).encode()), "test.json")
+
+
+def _xlsx_file(sheets):
+    """Build an in-memory XLSX upload from {sheet_name: [row_dicts]}."""
+    import pandas as pd
+
+    buf = io.BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        for sheet_name, rows in sheets.items():
+            pd.DataFrame(rows).to_excel(writer, sheet_name=sheet_name, index=False)
+    buf.seek(0)
+    return (buf, "test.xlsx")
 
 
 class TestIngestionIndex:
@@ -202,3 +215,112 @@ class TestApproveAll:
             assert db.session.get(BiomedicalConcept, "C001") is not None
             log = AuditLog.query.filter_by(entity_type="BiomedicalConcept", entity_id="C001", action="created_via_ingestion").first()
             assert log is not None
+
+
+class TestUploadSpecializations:
+    def test_sdtm_sheet_produces_specialization_records(self, client, app):
+        sheets = {
+            "SDTM_LB": [
+                {"vlm_group_id": "C001.SDTM", "bc_id": "C001", "short_name": "Test Spec", "sdtm_variable": "LBTESTCD", "data_type": "string"},
+                {"vlm_group_id": "C001.SDTM", "bc_id": "C001", "short_name": "Test Spec", "sdtm_variable": "LBORRES", "data_type": "decimal"},
+            ]
+        }
+        file_obj, filename = _xlsx_file(sheets)
+        client.post(
+            "/ingestion/upload",
+            data={"file": (file_obj, filename)},
+            content_type="multipart/form-data",
+        )
+        with app.app_context():
+            ir = IngestionRecord.query.filter_by(record_type="specialization").first()
+            assert ir is not None
+            assert ir.mapped["vlm_group_id"] == "C001.SDTM"
+            assert len(ir.decs) == 2
+
+    def test_bc_sheet_produces_bc_records(self, client, app):
+        sheets = {"BC_LB": [{"bc_id": "C002", "short_name": "HR", "definition": "Heart Rate"}]}
+        file_obj, filename = _xlsx_file(sheets)
+        client.post(
+            "/ingestion/upload",
+            data={"file": (file_obj, filename)},
+            content_type="multipart/form-data",
+        )
+        with app.app_context():
+            ir = IngestionRecord.query.filter_by(record_type="bc").first()
+            assert ir is not None
+            assert ir.mapped["bc_id"] == "C002"
+
+    def test_duplicate_vlm_group_id_flagged(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DatasetSpecialization(vlm_group_id="C12345.SDTM", bc_id=sample_bc, domain="SDTM"))
+            db.session.commit()
+        sheets = {"SDTM_LB": [{"vlm_group_id": "C12345.SDTM", "bc_id": "C12345", "sdtm_variable": "LBTESTCD"}]}
+        file_obj, filename = _xlsx_file(sheets)
+        client.post(
+            "/ingestion/upload",
+            data={"file": (file_obj, filename)},
+            content_type="multipart/form-data",
+        )
+        with app.app_context():
+            ir = IngestionRecord.query.filter_by(record_type="specialization").first()
+            assert ir.duplicate is True
+
+
+class TestApproveSpecialization:
+    def _upload_spec(self, client, bc_id="C001"):
+        sheets = {"SDTM_LB": [{"vlm_group_id": f"{bc_id}.SDTM", "bc_id": bc_id, "short_name": "Test Spec", "sdtm_variable": "LBTESTCD", "data_type": "string"}]}
+        file_obj, filename = _xlsx_file(sheets)
+        client.post(
+            "/ingestion/upload",
+            data={"file": (file_obj, filename)},
+            content_type="multipart/form-data",
+        )
+
+    def test_approve_creates_specialization_when_bc_exists(self, client, app, sample_bc):
+        self._upload_spec(client, bc_id=sample_bc)
+        with app.app_context():
+            ir = IngestionRecord.query.filter_by(record_type="specialization").first()
+            record_id = ir.id
+        client.post(f"/ingestion/approve/{record_id}")
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, f"{sample_bc}.SDTM")
+            assert spec is not None
+            assert spec.bc_id == sample_bc
+            assert len(spec.variables) == 1
+            ir = db.session.get(IngestionRecord, record_id)
+            assert ir.status == "approved"
+            log = AuditLog.query.filter_by(entity_type="DatasetSpecialization", entity_id=f"{sample_bc}.SDTM").first()
+            assert log is not None
+
+    def test_approve_leaves_pending_when_bc_missing(self, client, app):
+        self._upload_spec(client, bc_id="C_NOPE")
+        with app.app_context():
+            ir = IngestionRecord.query.filter_by(record_type="specialization").first()
+            record_id = ir.id
+        client.post(f"/ingestion/approve/{record_id}")
+        with app.app_context():
+            assert db.session.get(DatasetSpecialization, "C_NOPE.SDTM") is None
+            ir = db.session.get(IngestionRecord, record_id)
+            assert ir.status == "pending"
+
+
+class TestApproveAllSpecializations:
+    def test_bc_and_spec_from_same_upload_both_resolve(self, client, app):
+        sheets = {
+            "BC_LB": [{"bc_id": "C777", "short_name": "HR", "definition": "Heart Rate"}],
+            "SDTM_LB": [{"vlm_group_id": "C777.SDTM", "bc_id": "C777", "short_name": "HR Spec", "sdtm_variable": "LBTESTCD"}],
+        }
+        file_obj, filename = _xlsx_file(sheets)
+        with client.session_transaction() as sess:
+            sess["ingestion_key"] = "testkey"
+        client.post(
+            "/ingestion/upload",
+            data={"file": (file_obj, filename)},
+            content_type="multipart/form-data",
+        )
+        client.post("/ingestion/approve_all")
+        with app.app_context():
+            assert db.session.get(BiomedicalConcept, "C777") is not None
+            spec = db.session.get(DatasetSpecialization, "C777.SDTM")
+            assert spec is not None
+            assert spec.bc_id == "C777"

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -4,7 +4,11 @@ import io
 import json
 
 from services.ingestion import (
+    SPEC_FIELD_MAP,
+    VARIABLE_FIELDS,
+    _detect_record_type,
     _group_by_bc,
+    _group_by_spec,
     _match_field,
     _similarity,
     deduplicate,
@@ -12,6 +16,7 @@ from services.ingestion import (
     parse_csv,
     parse_json,
     validate_bc,
+    validate_specialization,
 )
 
 # ---------------------------------------------------------------------------
@@ -257,3 +262,172 @@ class TestGroupByBc:
         rows = [({"short_name": "Orphan", "definition": "No ID"}, {})]
         result = _group_by_bc(rows)
         assert result == []
+
+    def test_result_tagged_as_bc_record_type(self):
+        rows = [({"bc_id": "C001", "short_name": "HR", "definition": "Heart Rate"}, {})]
+        result = _group_by_bc(rows)
+        assert result[0]["record_type"] == "bc"
+
+
+# ---------------------------------------------------------------------------
+# map_fields with a custom field_map (SPEC_FIELD_MAP)
+# ---------------------------------------------------------------------------
+
+
+class TestMapFieldsWithFieldMap:
+    def test_uses_custom_field_map(self):
+        mapped, confs = map_fields({"vlm_group_id": "C001.SDTM"}, field_map=SPEC_FIELD_MAP)
+        assert mapped["vlm_group_id"] == "C001.SDTM"
+        assert confs["vlm_group_id"] == 1.0
+
+    def test_every_variable_column_maps_to_itself_exactly(self):
+        # Every SDTM VLM column (I-AF) is its own canonical field — an
+        # exact 1:1 map, not fuzzy-matched onto a different column, so two
+        # similarly-named columns (e.g. mandatory_variable vs
+        # mandatory_value) can never collide.
+        raw = {"codelist_submission_value": "X", "linking_phrase": "Y", "mandatory_variable": "Y", "mandatory_value": "N"}
+        mapped, confs = map_fields(raw, field_map=SPEC_FIELD_MAP)
+        assert mapped == {"codelist_submission_value": "X", "linking_phrase": "Y", "mandatory_variable": "Y", "mandatory_value": "N"}
+        assert all(score == 1.0 for score in confs.values())
+
+    def test_bc_only_columns_not_matched_by_spec_map(self):
+        # Fields that only exist on a BC/DEC (not a Dataset Specialization)
+        # should not be force-matched onto anything in SPEC_FIELD_MAP.
+        mapped, _ = map_fields({"definition": "X", "synonyms": "Y"}, field_map=SPEC_FIELD_MAP)
+        assert mapped == {}
+
+    def test_default_field_map_is_bc_field_map(self):
+        mapped, _ = map_fields({"bc_id": "C001"})
+        assert mapped["bc_id"] == "C001"
+
+
+# ---------------------------------------------------------------------------
+# _detect_record_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRecordType:
+    def test_sdtm_prefixed_sheet_is_specialization(self):
+        assert _detect_record_type(["short_name"], sheet_name="SDTM_LB") == "specialization"
+
+    def test_bc_prefixed_sheet_is_bc(self):
+        assert _detect_record_type(["vlm_group_id"], sheet_name="BC_LB") == "bc"
+
+    def test_cdash_prefixed_sheet_is_specialization(self):
+        assert _detect_record_type([], sheet_name="CDASH_LB") == "specialization"
+
+    def test_unrecognized_prefix_falls_back_to_column_signature(self):
+        assert _detect_record_type(["vlm_group_id", "bc_id"], sheet_name="Sheet1") == "specialization"
+        assert _detect_record_type(["short_name", "definition"], sheet_name="Sheet1") == "bc"
+
+    def test_no_sheet_name_uses_column_signature(self):
+        assert _detect_record_type(["vlm_group_id"]) == "specialization"
+        assert _detect_record_type(["short_name", "definition"]) == "bc"
+
+
+# ---------------------------------------------------------------------------
+# validate_specialization
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSpecialization:
+    def test_valid_record_has_no_errors(self):
+        assert validate_specialization({"vlm_group_id": "C001.SDTM", "bc_id": "C001"}) == []
+
+    def test_missing_vlm_group_id(self):
+        errors = validate_specialization({"bc_id": "C001"})
+        assert any("vlm_group_id" in e for e in errors)
+
+    def test_missing_bc_id(self):
+        errors = validate_specialization({"vlm_group_id": "C001.SDTM"})
+        assert any("bc_id" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# _group_by_spec
+# ---------------------------------------------------------------------------
+
+
+class TestGroupBySpec:
+    def test_single_row_becomes_one_spec(self):
+        rows = [({"vlm_group_id": "C001.SDTM", "bc_id": "C001", "short_name": "Test Spec"}, {})]
+        result = _group_by_spec(rows)
+        assert len(result) == 1
+        assert result[0]["mapped"]["vlm_group_id"] == "C001.SDTM"
+        assert result[0]["mapped"]["bc_id"] == "C001"
+        assert result[0]["record_type"] == "specialization"
+
+    def test_domain_taken_from_worksheet_column(self):
+        # domain holds the actual SDTM domain codelist value (e.g. "LB"),
+        # as stored in the worksheet's own domain column.
+        rows = [({"vlm_group_id": "C001.SDTM", "bc_id": "C001", "domain": "LB"}, {})]
+        result = _group_by_spec(rows)
+        assert result[0]["mapped"]["domain"] == "LB"
+
+    def test_domain_defaults_to_empty_when_column_absent(self):
+        rows = [({"vlm_group_id": "C001.SDTM", "bc_id": "C001"}, {})]
+        result = _group_by_spec(rows)
+        assert result[0]["mapped"]["domain"] == ""
+
+    def test_variable_rows_grouped_under_parent(self):
+        rows = [
+            ({"vlm_group_id": "C001.SDTM", "bc_id": "C001", "short_name": "Test Spec"}, {}),
+            ({"vlm_group_id": "C001.SDTM", "sdtm_variable": "LBTESTCD", "data_type": "string", "mandatory_variable": "Y"}, {}),
+            ({"vlm_group_id": "C001.SDTM", "sdtm_variable": "LBORRES", "data_type": "decimal", "dec_id": "C001.DEC.1"}, {}),
+        ]
+        result = _group_by_spec(rows)
+        assert len(result) == 1
+        variables = result[0]["variables"]
+        assert len(variables) == 2
+        assert variables[0]["sdtm_variable"] == "LBTESTCD"
+        assert variables[0]["data_type"] == "string"
+        assert variables[0]["mandatory_variable"] == "Y"
+        assert variables[0]["dec_id"] == ""
+        assert variables[1]["sdtm_variable"] == "LBORRES"
+        assert variables[1]["dec_id"] == "C001.DEC.1"
+        # Every VARIABLE_FIELDS column is present on every row, even when blank.
+        assert set(variables[0].keys()) == set(VARIABLE_FIELDS)
+
+    def test_multiple_specs_produce_separate_records(self):
+        rows = [
+            ({"vlm_group_id": "C001.SDTM", "bc_id": "C001"}, {}),
+            ({"vlm_group_id": "C002.SDTM", "bc_id": "C002"}, {}),
+        ]
+        result = _group_by_spec(rows)
+        assert len(result) == 2
+
+    def test_row_without_vlm_group_id_skipped(self):
+        rows = [({"bc_id": "C001"}, {})]
+        result = _group_by_spec(rows)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# deduplicate — specialization records
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateSpecializations:
+    def _spec_record(self, vlm_group_id):
+        return {
+            "record_type": "specialization",
+            "mapped": {"vlm_group_id": vlm_group_id},
+            "confidences": {},
+            "errors": [],
+            "variables": [],
+        }
+
+    def test_marks_existing_vlm_group_id_as_duplicate(self):
+        records = [self._spec_record("C001.SDTM")]
+        result = deduplicate(records, set(), existing_spec_ids={"C001.SDTM"})
+        assert result[0]["duplicate"] is True
+
+    def test_new_vlm_group_id_not_duplicate(self):
+        records = [self._spec_record("C999.SDTM")]
+        result = deduplicate(records, set(), existing_spec_ids={"C001.SDTM"})
+        assert result[0]["duplicate"] is False
+
+    def test_bc_records_unaffected_by_spec_ids(self):
+        records = [{"record_type": "bc", "mapped": {"bc_id": "C001"}, "confidences": {}, "errors": [], "decs": []}]
+        result = deduplicate(records, {"C001"}, existing_spec_ids={"C999.SDTM"})
+        assert result[0]["duplicate"] is True

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -50,6 +50,8 @@ class TestDispatch:
             "submit_bc_for_review",
             "advance_governance",
             "reject_bc",
+            "advance_specialization_governance",
+            "reject_specialization",
         }
         assert {tool.name for tool in mcp_srv._TOOLS} == expected
 
@@ -106,6 +108,7 @@ class TestGetBc:
         assert result["bc_id"] == sample_bc
         assert result["decs"][0]["dec_label"] == "Result"
         assert result["specializations"][0]["vlm_group_id"] == f"{sample_bc}.SDTM"
+        assert result["specializations"][0]["status"] == "provisional"
         assert result["governance_records"][0]["action"] == "advanced"
 
 
@@ -299,12 +302,53 @@ class TestGovernanceWrites:
             assert rec.actor == "mcp"
         assert len(_audit_rows(app, "rejected")) == 1
 
+    def test_submit_spec_then_advance_to_published(self, app, sample_spec):
+        first = _dispatch("advance_specialization_governance", {"vlm_group_id": sample_spec, "comment": "looks good"})
+        assert first == {"vlm_group_id": sample_spec, "short_name": "Test Spec", "status": "sme_review", "advanced": True}
+
+        second = _dispatch("advance_specialization_governance", {"vlm_group_id": sample_spec})
+        assert second["status"] == "cdisc_approval"
+
+        third = _dispatch("advance_specialization_governance", {"vlm_group_id": sample_spec})
+        assert third["status"] == "published"
+
+        fourth = _dispatch("advance_specialization_governance", {"vlm_group_id": sample_spec})
+        assert fourth["advanced"] is False
+        assert fourth["status"] == "published"
+
+        with app.app_context():
+            recs = GovernanceRecord.query.filter_by(vlm_group_id=sample_spec).order_by(GovernanceRecord.id).all()
+            assert [r.action for r in recs] == ["advanced", "advanced", "advanced"]
+            assert recs[0].actor == "mcp"
+            assert recs[0].comment == "looks good"
+        assert len(_audit_rows(app, "status_changed")) == 3
+
+    def test_reject_spec_returns_to_provisional(self, app, sample_spec):
+        _dispatch("advance_specialization_governance", {"vlm_group_id": sample_spec})
+        result = _dispatch("reject_specialization", {"vlm_group_id": sample_spec, "comment": "needs work"})
+        assert result["status"] == "provisional"
+        with app.app_context():
+            rec = GovernanceRecord.query.filter_by(vlm_group_id=sample_spec, action="rejected").one()
+            assert rec.stage == 0
+            assert rec.actor == "mcp"
+        assert len(_audit_rows(app, "rejected")) == 1
+
+    def test_advance_spec_missing_id_raises(self):
+        with pytest.raises(ValueError, match="vlm_group_id is required"):
+            _dispatch("advance_specialization_governance", {})
+
+    def test_advance_spec_missing_spec_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            _dispatch("advance_specialization_governance", {"vlm_group_id": "NOPE"})
+
 
 class TestReviewQueue:
-    def test_queue_summary(self, app, sample_bc):
+    def test_queue_summary(self, app, sample_bc, sample_spec):
         with app.app_context():
             bc = db.session.get(BiomedicalConcept, sample_bc)
             bc.status = "sme_review"
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            spec.status = "sme_review"
             db.session.add(IngestionRecord(session_key="s", mapped={"bc_id": "X"}, status="pending"))
             db.session.add(IngestionRecord(session_key="s", mapped={"bc_id": "Y"}, status="approved"))
             db.session.commit()
@@ -313,3 +357,5 @@ class TestReviewQueue:
         assert result["sme_review"][0]["bc_id"] == sample_bc
         assert result["cdisc_approval"] == []
         assert result["pending_ingestion_records"] == 1
+        assert result["specializations"]["sme_review"][0]["vlm_group_id"] == sample_spec
+        assert result["specializations"]["cdisc_approval"] == []

--- a/tests/test_specializations_routes.py
+++ b/tests/test_specializations_routes.py
@@ -62,6 +62,17 @@ class TestCreate:
             assert spec.domain == "CDASH"
             assert spec.variables == []
 
+    def test_create_defaults_to_provisional_status(self, client, app, sample_bc):
+        patcher, _ = _patch_client()
+        with patcher:
+            client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM2", "bc_id": sample_bc, "domain": "CDASH", "short_name": "Manual Spec"},
+            )
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, "VLM2")
+            assert spec.status == "provisional"
+
     def test_create_requires_ids(self, client, app):
         patcher, _ = _patch_client()
         with patcher:

--- a/tests/test_specializations_routes.py
+++ b/tests/test_specializations_routes.py
@@ -4,11 +4,17 @@ from unittest.mock import MagicMock, patch
 
 from extensions import db
 from models.audit import AuditLog
-from models.bc import DataElementConcept
+from models.bc import BiomedicalConcept, DataElementConcept
 from models.specialization import DatasetSpecialization
 
 LIBRARY_LINKS = [
     {"href": "/mdr/bc/biomedicalconcepts/C64849", "title": "Hemoglobin A1c"},
+]
+
+DOMAIN_CODES = [
+    {"code": "AE", "label": "Adverse Event Domain"},
+    {"code": "LB", "label": "Laboratory Test Results Domain"},
+    {"code": "VS", "label": "Vital Signs Domain"},
 ]
 
 
@@ -17,6 +23,7 @@ def _patch_client(**kwargs):
     client = MagicMock()
     client.get_biomedical_concepts.return_value = kwargs.get("bcs", LIBRARY_LINKS)
     client.get_specialization.return_value = kwargs.get("spec", {})
+    client.get_sdtm_domain_codes.return_value = kwargs.get("domains", DOMAIN_CODES)
     patcher = patch("routes.specializations.CDISCApiClient", return_value=client)
     return patcher, client
 
@@ -63,6 +70,28 @@ class TestCreate:
         with app.app_context():
             assert DatasetSpecialization.query.count() == 0
 
+    def test_create_requires_domain(self, client, app, sample_bc):
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM1", "bc_id": sample_bc, "domain": ""},
+            )
+        assert resp.status_code == 302
+        with app.app_context():
+            assert DatasetSpecialization.query.count() == 0
+
+    def test_real_sdtm_domain_code_persists(self, client, app, sample_bc):
+        patcher, _ = _patch_client()
+        with patcher:
+            client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM1", "bc_id": sample_bc, "domain": "VS", "short_name": "Vitals Spec"},
+            )
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, "VLM1")
+            assert spec.domain == "VS"
+
     def test_create_writes_audit_log(self, client, app, sample_bc):
         patcher, _ = _patch_client()
         with patcher:
@@ -85,16 +114,18 @@ class TestCreate:
                     "bc_id": sample_bc,
                     "domain": "SDTM",
                     "short_name": "Manual Spec",
-                    "variables[0][name]": "RESULT",
-                    "variables[0][label]": "Result",
+                    "variables[0][sdtm_variable]": "RESULT",
                     "variables[0][data_type]": "decimal",
-                    "variables[0][required]": "on",
+                    "variables[0][mandatory_variable]": "Y",
                 },
             )
         assert resp.status_code == 302
         with app.app_context():
             spec = db.session.get(DatasetSpecialization, "VLM1")
-            assert spec.variables == [{"name": "RESULT", "label": "Result", "data_type": "decimal", "required": True}]
+            assert len(spec.variables) == 1
+            assert spec.variables[0]["sdtm_variable"] == "RESULT"
+            assert spec.variables[0]["data_type"] == "decimal"
+            assert spec.variables[0]["mandatory_variable"] == "Y"
 
 
 class TestEditUpsert:
@@ -111,8 +142,7 @@ class TestEditUpsert:
                     "bc_id": sample_bc,
                     "domain": "CDASH",
                     "short_name": "Renamed",
-                    "variables[0][name]": "RESULT",
-                    "variables[0][label]": "Result",
+                    "variables[0][sdtm_variable]": "RESULT",
                     "variables[0][data_type]": "decimal",
                 },
             )
@@ -122,7 +152,9 @@ class TestEditUpsert:
             spec = db.session.get(DatasetSpecialization, "VLM1")
             assert spec.domain == "CDASH"
             assert spec.short_name == "Renamed"
-            assert spec.variables == [{"name": "RESULT", "label": "Result", "data_type": "decimal", "required": False}]
+            assert len(spec.variables) == 1
+            assert spec.variables[0]["sdtm_variable"] == "RESULT"
+            assert spec.variables[0]["data_type"] == "decimal"
 
     def test_edit_writes_updated_audit_log(self, client, app, sample_bc):
         with app.app_context():
@@ -188,6 +220,26 @@ class TestDetail:
             resp = client.get("/specializations/NOPE")
         assert resp.status_code == 404
 
+    def test_detail_expands_the_edit_form_panel(self, client, app, sample_bc):
+        """The Edit link on the list page routes here; the pre-filled form
+        must actually be visible, not left inside a collapsed <div>."""
+        with app.app_context():
+            db.session.add(DatasetSpecialization(vlm_group_id="VLM1", bc_id=sample_bc, domain="SDTM"))
+            db.session.commit()
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.get("/specializations/VLM1")
+        body = resp.data.decode()
+        assert 'id="specialization-form-panel"' in body
+        assert 'class="collapse mb-3 show"' in body
+
+    def test_index_form_panel_collapsed_by_default(self, client):
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.get("/specializations/")
+        body = resp.data.decode()
+        assert 'class="collapse mb-3 "' in body
+
 
 class TestLibraryDetail:
     def test_renders_library_spec(self, client):
@@ -215,6 +267,13 @@ class TestGenerate:
             )
             db.session.commit()
 
+    def test_generate_requires_domain(self, client, app, sample_bc):
+        self._add_decs(app, sample_bc)
+        resp = client.post(f"/specializations/generate/{sample_bc}", data={"domain": ""})
+        assert resp.status_code == 302
+        with app.app_context():
+            assert DatasetSpecialization.query.count() == 0
+
     def test_generate_builds_variables_from_decs(self, client, app, sample_bc):
         self._add_decs(app, sample_bc)
         resp = client.post(f"/specializations/generate/{sample_bc}", data={"domain": "SDTM"})
@@ -222,8 +281,8 @@ class TestGenerate:
         with app.app_context():
             spec = db.session.get(DatasetSpecialization, f"{sample_bc}.SDTM")
             assert spec is not None
-            assert [v["name"] for v in spec.variables] == ["Result", "Unit"]
-            assert spec.variables[0]["required"] is True
+            assert [v["sdtm_variable"] for v in spec.variables] == ["Result", "Unit"]
+            assert spec.variables[0]["dec_id"] == f"{sample_bc}.DEC.1"
 
     def test_generate_duplicate_is_rejected(self, client, app, sample_bc):
         self._add_decs(app, sample_bc)
@@ -253,8 +312,75 @@ class TestGenerateFromDec:
         resp = client.post("/specializations/generate-from-dec", json={"bc_id": sample_bc})
         assert resp.status_code == 200
         payload = resp.get_json()
-        assert payload["variables"][0]["name"] == "Result"
+        assert payload["variables"][0]["sdtm_variable"] == "Result"
+        assert payload["variables"][0]["dec_id"] == "D1"
 
     def test_missing_bc_id_returns_400(self, client):
         resp = client.post("/specializations/generate-from-dec", json={})
         assert resp.status_code == 400
+
+
+class TestCreateWithLibraryOnlyBc:
+    def test_selecting_library_only_bc_creates_local_stub(self, client, app):
+        """Picking a 'CDISC Library' option that has no local BC row yet
+        must not create an orphaned FK reference — it should create a
+        minimal local BC stub so the specialization links correctly."""
+        patcher, _ = _patch_client(bcs=[{"href": "/mdr/bc/biomedicalconcepts/C64849", "title": "Hemoglobin A1c"}])
+        with patcher:
+            resp = client.post(
+                "/specializations/",
+                data={"vlm_group_id": "C64849.SDTM", "bc_id": "C64849", "domain": "SDTM", "short_name": "HBA1C Spec"},
+            )
+        assert resp.status_code == 302
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C64849")
+            assert bc is not None
+            assert bc.status == "provisional"
+            spec = db.session.get(DatasetSpecialization, "C64849.SDTM")
+            assert spec is not None
+            assert spec.bc_id == "C64849"
+            assert spec.bc is not None
+            assert spec.bc.bc_id == "C64849"
+
+    def test_existing_local_bc_is_not_modified(self, client, app, sample_bc):
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM1", "bc_id": sample_bc, "domain": "SDTM", "short_name": "Manual Spec"},
+            )
+        assert resp.status_code == 302
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, sample_bc)
+            assert bc.short_name == "Test Concept"
+
+
+class TestBcOptionsSorting:
+    def test_library_bcs_sorted_alphabetically(self, client):
+        unsorted_links = [
+            {"href": "/mdr/bc/biomedicalconcepts/C2", "title": "Zebra Concept"},
+            {"href": "/mdr/bc/biomedicalconcepts/C1", "title": "Alpha Concept"},
+        ]
+        patcher, _ = _patch_client(bcs=unsorted_links)
+        with patcher:
+            resp = client.get("/specializations/")
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert body.index("Alpha Concept") < body.index("Zebra Concept")
+
+
+class TestDomainSelector:
+    def test_domain_options_rendered_from_sdtm_codelist(self, client):
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.get("/specializations/")
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert "Adverse Event Domain" in body
+        assert "Vital Signs Domain" in body
+
+    def test_error_entries_excluded_from_options(self, client):
+        patcher, _ = _patch_client(domains=[{"error": "unreachable"}])
+        with patcher:
+            resp = client.get("/specializations/")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Teach the `/ingestion` upload+review pipeline to recognize `BC_`/`SDTM_`/`CDASH_` worksheet sheets and import Dataset Specializations (grouped by `vlm_group_id`) alongside the existing BC import, since the Specializations page had no bulk-import path before this.
- Map every real SDTM VLM worksheet column (I-AF, 24 fields) 1:1 to itself in the field mapper — the previous small fuzzy-matched field map let similarly-named columns (e.g. `assigned_value`) silently clobber `sdtm_variable` within the same row, corrupting imported variable data.
- Replace the Specialization form's `SDTM`/`CDASH` toggle with a dropdown populated live from the CDISC Library's SDTM Domain Abbreviation codelist (C66734, latest package) — `domain` is a real SDTM domain code (`LB`, `VS`, ...), not a two-value toggle.
- Fix the BC picker silently creating orphaned specializations when a Library-only BC is chosen (SQLite FK enforcement is off) by auto-creating a minimal local BC stub.
- Fix the Edit button on the Specializations list — the pre-filled form loaded correctly but stayed hidden inside a collapsed Bootstrap panel.
- Fix two dead-attribute template bugs (`spec.bc_name`, `spec.variable_count`) that silently showed the raw `bc_id` and "0 variables" for every row.
- New Alembic migration adds `IngestionRecord.record_type` (`"bc"` / `"specialization"`).

## Test plan
- [x] `pytest --tb=short` — 293 passing
- [x] `flake8 .` — clean
- [x] Manual smoke test: uploaded the real `files/BC Examples.xlsx` via `/ingestion`, approved all, confirmed 25 BCs + 22 specializations landed correctly (1 correctly held pending — its BC wasn't in that workbook's BC sheets)
- [x] Confirmed `KETONESURIN` imports exactly 11 variable rows with correct values in worksheet order
- [x] Confirmed the domain dropdown renders all 85 real SDTM domain codes from the live CDISC Library API
- [x] Confirmed the Edit button now opens the specialization form expanded

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>