### PR TITLE
Fix DECs disappearing on save and align exports with BC Examples.xlsx

### DIFF
--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -30,6 +30,34 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 
 ### 2026-09-01
 
+#### Made the ncit_dec_code Export Column Mirror dec_id
+
+- In the exported `BC_LB`/`BC_VS` xlsx sheet, column M (`dec_id`) was populated correctly but column N (`ncit_dec_code`) was left at whatever was stored on the DEC (typically blank, since the BC detail form no longer exposes it as a separate field — see the DEC ID entry below). Made the export always populate column N with the same value as column M.
+- `services/export.py` — `export_governance_xlsx()`'s per-DEC row loop now special-cases the `ncit_dec_code` header to use `dec.dec_id` instead of the DEC's stored `ncit_dec_code` attribute. This is an export-time transformation only (nothing is rewritten in the database), applied uniformly since both `/bc/export?format=xlsx` and `/governance/export` share this function.
+- Wrote the test first (TDD): `TestExportGovernanceXlsx.test_ncit_dec_code_column_mirrors_dec_id` and `test_ncit_dec_code_column_overrides_a_stored_distinct_value` in `tests/test_export_service.py` confirm column N always equals column M, even when a DEC has a different stored `ncit_dec_code`; 361 tests passing, isort/black/flake8 clean ✅
+- Verified against a live dev server on a throwaway DB/port: created a BC with a DEC (`dec_id=C64849.DEC.1`), downloaded `/bc/export?format=xlsx`, and confirmed columns M and N both read `C64849.DEC.1` on the DEC row (both blank on the BC-only row, as expected).
+
+#### Added a Visible, Editable DEC ID Field to the BC Detail Form
+
+- The DEC table's `dec_id` value (the column that populates `dec_id` in `files/BC Examples.xlsx`) was a hidden input, silently auto-generated as `{bc_id}.DEC.{n}` if left blank — curators had no way to see or set it directly, e.g. to match a CDISC-published DEC id like `C64849.DEC.1`. Made it a visible text column, positioned before "DEC Label" as requested.
+- `templates/bc_detail.html` — added a `DEC ID` `<th>` before `DEC Label`; the per-row `dec_id` input changed from `type="hidden"` to a visible `form-control form-control-sm` text input (matching the styling of the other DEC fields), still positioned first in the row. `ncit_dec_code` remains a hidden input (not part of this request).
+- `static/js/main.js` — `buildDecRow()` updated to match: new rows get the same visible DEC ID cell ahead of DEC Label.
+- No backend changes needed — `routes/bc.py`'s `_decs_from_form()` and `services/bc_service.save_decs()` already read/persist `dec_id` (from the earlier DEC-save-bug fix) and still auto-generate one when the field is left blank, so this is purely a UI change plus a regression test.
+- Wrote the test first (TDD): `TestBcDetail.test_dec_id_field_is_visible_and_precedes_label` in `tests/test_bc_routes.py` asserts the "DEC ID" header precedes "DEC Label" and that the input is a visible `type="text"` field carrying the DEC's value; 359 tests passing, isort/black/flake8 clean ✅
+- Verified end-to-end against a live dev server on a throwaway DB/port: created a BC with an explicit custom `dec_id` (`C64849.DEC.1`) via the form, confirmed it rendered in the new visible field, and confirmed it flowed through unchanged into the `dec_id` column of the `/bc/export?format=xlsx` output.
+
+#### Fixed DECs Disappearing on Save; Included DECs in All BC Exports
+
+- Adding DECs to a BC on the detail form and clicking Save silently deleted them: the rendered table and `static/js/main.js` submit DEC fields as `decs[N][dec_label]` etc., but `routes/bc.py`'s `_decs_from_form()` was still reading obsolete flat-array names (`dec_label[]`) that the form never sent, so it always parsed zero DECs and `save_decs()`'s delete-then-recreate logic wiped every existing DEC and added nothing back — on both create and edit.
+- `routes/bc.py` — rewrote `_decs_from_form()` to parse the actual `decs[N][field]` keys via regex, grouped and ordered by row index.
+- `templates/bc_detail.html` / `static/js/main.js` — added hidden `decs[N][dec_id]`/`decs[N][ncit_dec_code]` inputs (previously never emitted at all) so editing an existing DEC preserves its identity/NCIt code instead of `save_decs` regenerating a new `dec_id` on every save.
+- `services/bc_service.py` — `save_decs()` now also persists the `required` checkbox onto `DataElementConcept.required`, which the form submitted but the service silently discarded.
+- Separately, DECs weren't reaching any BC export either: `/bc/export?format=xlsx` used an old exporter (`export_xlsx`/`BC_EXPORT_FIELDS`) with no DEC columns/rows at all and the wrong sheet name, while a newer exporter (`export_governance_xlsx`) already matched the reference `files/BC Examples.xlsx` `BC_LB` shape (BC row + one row per DEC, BC columns repeated) but was wired only to the published-only `/governance/export` route. Pointed `/bc/export`'s xlsx branch at `export_governance_xlsx` instead and removed the now-dead `export_xlsx`/`BC_EXPORT_FIELDS`.
+- `models/bc.py` — `BiomedicalConcept.to_dict()` now includes a `decs` list (skipped gracefully for a transient, not-yet-session-bound BC), so JSON export carries DEC data too.
+- `services/export.py` — `export_odm_xml()` now emits a DEC-derived `ItemDef` per DEC (data-type mapped to ODM's, NCIt alias when present).
+- Wrote tests first (TDD): fixed `TestCreateBc.test_create_with_decs` (previously posted a fictitious flat-array shape the browser never sends), added DEC coverage to `TestEditBc` (unchanged/updated/added/removed rows, `required` persistence), a new `TestSaveDecs` unit-test class in `tests/test_bc_service.py` (previously zero coverage), strengthened `TestExport` in `tests/test_bc_routes.py` and `TestExportOdmXml`/removed the now-dead `TestExportXlsx` in `tests/test_export_service.py`, and added `to_dict()` DEC tests to `tests/test_models.py`; 358 tests passing, isort/black/flake8 clean ✅
+- Verified end-to-end against a live dev server on a throwaway DB/port: created a BC with 2 DECs via the real `decs[N][field]` form shape and confirmed both rendered; edited it (updated one DEC, dropped one, added one) in a single save and confirmed the detail page reflected exactly that; confirmed `/bc/export` in JSON, XLSX (`BC_LB` sheet, correct row/column shape), and ODM-XML all carry the DEC data.
+
 #### Reordered the Definition Section on the BC Detail Form
 
 - `templates/bc_detail.html` — moved the "Definition" `bc-card` block (textarea for `definition`) to appear right after the top summary section, ahead of the NCIt/LOINC panels; it previously sat lower on the page, after the LOINC results container. Template-only reorder, no field/logic changes.

--- a/models/bc.py
+++ b/models/bc.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+from sqlalchemy.orm import object_session
+
 from extensions import db
 
 # Alphabetically sorted result scale options a BC's result_scales field may
@@ -50,6 +52,25 @@ class BiomedicalConcept(db.Model):
     specializations = db.relationship("DatasetSpecialization", backref="bc", lazy="dynamic", cascade="all, delete-orphan")
 
     def to_dict(self):
+        # self.decs is a lazy="dynamic" relationship, which requires the
+        # instance to be session-bound to query — a transient BC that was
+        # never added to a session (e.g. one built ad hoc, not yet saved)
+        # has no DECs to report yet, so skip the query rather than raising.
+        decs = (
+            [
+                {
+                    "dec_id": dec.dec_id,
+                    "ncit_dec_code": dec.ncit_dec_code,
+                    "dec_label": dec.dec_label,
+                    "data_type": dec.data_type,
+                    "example_set": dec.example_set,
+                    "required": dec.required,
+                }
+                for dec in self.decs.order_by(DataElementConcept.sort_order)
+            ]
+            if object_session(self) is not None
+            else []
+        )
         return {
             "bc_id": self.bc_id,
             "short_name": self.short_name,
@@ -65,6 +86,7 @@ class BiomedicalConcept(db.Model):
             "package_date": self.package_date,
             "status": self.status,
             "submitter": self.submitter,
+            "decs": decs,
         }
 
 

--- a/routes/bc.py
+++ b/routes/bc.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from datetime import datetime, timezone
 
 from flask import Blueprint, Response, flash, redirect, render_template, request, url_for
@@ -10,7 +11,7 @@ from models.governance import GovernanceRecord
 from services import bc_service
 from services.audit import log_change
 from services.cdisc_api import CDISCApiClient
-from services.export import export_json, export_odm_xml, export_xlsx
+from services.export import export_governance_xlsx, export_json, export_odm_xml
 from services.loinc_api import LoincApiClient
 from services.ncit_api import NCItApiClient
 
@@ -74,15 +75,15 @@ def new_bc():
 @bp.route("/export")
 def export():
     fmt = request.args.get("format", "json")
-    bcs = [bc.to_dict() for bc in BiomedicalConcept.query.all()]
     if fmt == "xlsx":
-        buf = export_xlsx(bcs)
+        buf = export_governance_xlsx(BiomedicalConcept.query.all())
         return Response(
             buf,
             mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             headers={"Content-Disposition": "attachment; filename=bcs.xlsx"},
         )
-    elif fmt == "odm":
+    bcs = [bc.to_dict() for bc in BiomedicalConcept.query.all()]
+    if fmt == "odm":
         xml = export_odm_xml(bcs)
         return Response(
             xml,
@@ -277,22 +278,30 @@ def delete(bc_id):
     return redirect(url_for("bc.index"))
 
 
+_DEC_FIELD_RE = re.compile(r"^decs\[(\d+)\]\[(\w+)\]$")
+
+
 def _decs_from_form(form):
-    """Convert the parallel dec_*[] form lists into a list of dicts for
-    bc_service.save_decs, preserving row positions (blank labels keep
-    their slot so default dec_id numbering matches the form rows)."""
-    labels = form.getlist("dec_label[]")
-    dtypes = form.getlist("dec_data_type[]")
-    examples = form.getlist("dec_example_set[]")
-    dec_ids = form.getlist("dec_id[]")
-    ncit_codes = form.getlist("dec_ncit_code[]")
+    """Convert the decs[N][field] fields submitted by the DEC table
+    (server-rendered rows and rows added via static/js/main.js
+    buildDecRow()) into a list of dicts for bc_service.save_decs, ordered by
+    row index (blank labels keep their slot so default dec_id numbering
+    matches the form rows)."""
+    rows = {}
+    for key in form.keys():
+        match = _DEC_FIELD_RE.match(key)
+        if not match:
+            continue
+        index, field = int(match.group(1)), match.group(2)
+        rows.setdefault(index, {})[field] = form.get(key)
     return [
         {
-            "dec_id": dec_ids[i] if i < len(dec_ids) else "",
-            "ncit_dec_code": ncit_codes[i] if i < len(ncit_codes) else "",
-            "dec_label": label,
-            "data_type": dtypes[i] if i < len(dtypes) else "string",
-            "example_set": examples[i] if i < len(examples) else "",
+            "dec_id": row.get("dec_id", ""),
+            "ncit_dec_code": row.get("ncit_dec_code", ""),
+            "dec_label": row.get("dec_label", ""),
+            "data_type": row.get("data_type") or "string",
+            "example_set": row.get("example_set", ""),
+            "required": row.get("required") == "1",
         }
-        for i, label in enumerate(labels)
+        for _, row in sorted(rows.items())
     ]

--- a/services/bc_service.py
+++ b/services/bc_service.py
@@ -109,8 +109,8 @@ def save_decs(bc_id, decs):
     """Replace the BC's Data Element Concepts with the given list of dicts.
 
     Each dict may carry dec_id, ncit_dec_code, dec_label, data_type,
-    example_set. An empty list clears all DECs; rows with a blank label are skipped but
-    keep their position for default dec_id numbering.
+    example_set, required. An empty list clears all DECs; rows with a blank
+    label are skipped but keep their position for default dec_id numbering.
     """
     DataElementConcept.query.filter_by(bc_id=bc_id).delete()
     for i, dec in enumerate(decs or []):
@@ -125,6 +125,7 @@ def save_decs(bc_id, decs):
                 dec_label=label,
                 data_type=dec.get("data_type") or "string",
                 example_set=dec.get("example_set", ""),
+                required=bool(dec.get("required")),
                 sort_order=i,
             )
         )

--- a/services/export.py
+++ b/services/export.py
@@ -35,55 +35,20 @@ SPEC_SHEET_HEADER_FIELDS = [
     "short_name",
 ]
 
-
-BC_EXPORT_FIELDS = [
-    "bc_id",
-    "short_name",
-    "definition",
-    "ncit_code",
-    "parent_bc_id",
-    "bc_categories",
-    "synonyms",
-    "result_scales",
-    "system",
-    "system_name",
-    "code",
-    "package_date",
-    "status",
-]
+# DataElementConcept.data_type values -> ODM-XML ItemDef DataType.
+DEC_ODM_DATA_TYPES = {
+    "string": "text",
+    "decimal": "float",
+    "integer": "integer",
+    "boolean": "boolean",
+    "date": "date",
+    "datetime": "datetime",
+}
 
 
 def export_json(bc_list):
     """Export list of BC dicts to JSON string."""
     return json.dumps(bc_list, indent=2, default=str)
-
-
-def export_xlsx(bc_list):
-    """Export list of BC dicts to BytesIO XLSX."""
-    if openpyxl is None:
-        raise ImportError("openpyxl is required for XLSX export")
-    wb = openpyxl.Workbook()
-    ws = wb.active
-    ws.title = "Biomedical Concepts"
-
-    header_fill = PatternFill("solid", fgColor="003366")
-    header_font_white = Font(bold=True, color="FFFFFF")
-
-    for col_idx, field in enumerate(BC_EXPORT_FIELDS, start=1):
-        cell = ws.cell(row=1, column=col_idx, value=field.replace("_", " ").title())
-        cell.font = header_font_white
-        cell.fill = header_fill
-        cell.alignment = Alignment(horizontal="center")
-
-    for row_idx, bc in enumerate(bc_list, start=2):
-        for col_idx, field in enumerate(BC_EXPORT_FIELDS, start=1):
-            value = bc.get("loinc_code", "") if field == "code" else bc.get(field, "")
-            ws.cell(row=row_idx, column=col_idx, value=value)
-
-    buf = io.BytesIO()
-    wb.save(buf)
-    buf.seek(0)
-    return buf
 
 
 GOVERNANCE_BC_FIELDS = [
@@ -157,6 +122,11 @@ def export_governance_xlsx(bc_objects, spec_objects=None):
                     val = bc_vals[header]
                 elif header == "History of Change":
                     val = bc_vals["History of Change"]
+                elif header == "ncit_dec_code":
+                    # DEC ID is the only identifier curators set through the
+                    # UI, so the legacy ncit_dec_code column always mirrors
+                    # it on export rather than the (now unused) stored value.
+                    val = dec.dec_id or ""
                 else:
                     val = getattr(dec, header, "") or ""
                 ws.cell(row=row_idx, column=col_idx, value=val)
@@ -244,5 +214,25 @@ def export_odm_xml(bc_list):
                     "Name": bc.get("ncit_code", ""),
                 },
             )
+
+        for dec in bc.get("decs") or []:
+            dec_item_def = etree.SubElement(
+                root,
+                "ItemDef",
+                attrib={
+                    "OID": dec.get("dec_id", ""),
+                    "Name": dec.get("dec_label", ""),
+                    "DataType": DEC_ODM_DATA_TYPES.get(dec.get("data_type"), "text"),
+                },
+            )
+            if dec.get("ncit_dec_code"):
+                etree.SubElement(
+                    dec_item_def,
+                    "Alias",
+                    attrib={
+                        "Context": "nci:ExtCodeID",
+                        "Name": dec.get("ncit_dec_code", ""),
+                    },
+                )
 
     return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8").decode()

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -304,6 +304,12 @@
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td>
+        <input type="hidden" name="decs[${index}][ncit_dec_code]" value="">
+        <input type="text" class="form-control form-control-sm"
+               name="decs[${index}][dec_id]"
+               placeholder="DEC ID" aria-label="DEC ID">
+      </td>
+      <td>
         <input type="text" class="form-control form-control-sm"
                name="decs[${index}][dec_label]"
                placeholder="DEC label" aria-label="DEC label">

--- a/templates/bc_detail.html
+++ b/templates/bc_detail.html
@@ -357,6 +357,7 @@
           <table class="dec-table" aria-label="Data element concepts">
             <thead>
               <tr>
+                <th scope="col">DEC ID</th>
                 <th scope="col">DEC Label</th>
                 <th scope="col">Data Type</th>
                 <th scope="col">Example Values</th>
@@ -368,6 +369,13 @@
               {% if bc and bc.decs %}
                 {% for dec in bc.decs %}
                 <tr>
+                  <td>
+                    <input type="hidden" name="decs[{{ loop.index0 }}][ncit_dec_code]" value="{{ dec.ncit_dec_code | default('') }}">
+                    <input type="text" class="form-control form-control-sm"
+                           name="decs[{{ loop.index0 }}][dec_id]"
+                           value="{{ dec.dec_id }}"
+                           aria-label="DEC ID">
+                  </td>
                   <td>
                     <input type="text" class="form-control form-control-sm"
                            name="decs[{{ loop.index0 }}][dec_label]"

--- a/tests/test_bc_routes.py
+++ b/tests/test_bc_routes.py
@@ -1,6 +1,10 @@
 """Tests for routes/bc.py — CRUD, export, submission."""
 
+import io
+import json
 from unittest.mock import patch
+
+import openpyxl
 
 from extensions import db
 from models.audit import AuditLog
@@ -115,17 +119,21 @@ class TestCreateBc:
             assert bc.result_scales == ""
 
     def test_create_with_decs(self, client, app):
+        """Reflects the actual decs[N][field] naming the rendered DEC table
+        and static/js/main.js buildDecRow() submit, not a legacy shape."""
         data = _bc_form()
-        data["dec_label[]"] = ["Systolic", "Diastolic"]
-        data["dec_data_type[]"] = ["decimal", "decimal"]
-        data["dec_example_set[]"] = ["120", "80"]
-        data["dec_id[]"] = ["", ""]
-        data["dec_ncit_code[]"] = ["", ""]
+        data["decs[0][dec_label]"] = "Systolic"
+        data["decs[0][data_type]"] = "decimal"
+        data["decs[0][example_set]"] = "120"
+        data["decs[1][dec_label]"] = "Diastolic"
+        data["decs[1][data_type]"] = "decimal"
+        data["decs[1][example_set]"] = "80"
         client.post("/bc/", data=data)
         with app.app_context():
-            decs = DataElementConcept.query.filter_by(bc_id="C00001").all()
+            decs = DataElementConcept.query.filter_by(bc_id="C00001").order_by(DataElementConcept.sort_order).all()
             assert len(decs) == 2
             assert decs[0].dec_label == "Systolic"
+            assert decs[1].dec_label == "Diastolic"
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +163,20 @@ class TestBcDetail:
         assert r.status_code == 200
         assert re.search(rb'value="Ordinal"\s*checked', r.data)
         assert not re.search(rb'value="Nominal"\s*checked', r.data)
+
+    def test_dec_id_field_is_visible_and_precedes_label(self, client, app, sample_bc):
+        """DEC ID must be a visible, editable column (not the old hidden
+        input) and must appear before DEC Label so curators can see/set the
+        value that populates the dec_id column in BC Examples.xlsx."""
+        import re
+
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0))
+            db.session.commit()
+        r = client.get(f"/bc/{sample_bc}")
+        html = r.data.decode()
+        assert html.index(">DEC ID<") < html.index(">DEC Label<")
+        assert re.search(r'<input type="text"[^>]*name="decs\[0\]\[dec_id\]"[^>]*value="C12345\.DEC\.1"', html)
 
     def test_unsupported_result_scale_shown_in_red(self, client, app, sample_bc):
         with app.app_context():
@@ -415,6 +437,105 @@ class TestEditBc:
         assert b'value="None"' not in r.data
         assert b'name="ncit_code"' in r.data
 
+    # -----------------------------------------------------------------------
+    # DEC persistence via edit (regression: decs[N][field] naming used by the
+    # rendered table/static/js/main.js must match what the route parses,
+    # otherwise every save wipes the BC's DECs)
+    # -----------------------------------------------------------------------
+
+    def test_edit_keeps_unchanged_decs(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", example_set="120", sort_order=0))
+            db.session.commit()
+        client.post(
+            "/bc/C12345/edit",
+            data={
+                "decs[0][dec_id]": "C12345.DEC.1",
+                "decs[0][dec_label]": "Systolic",
+                "decs[0][data_type]": "decimal",
+                "decs[0][example_set]": "120",
+            },
+        )
+        with app.app_context():
+            decs = DataElementConcept.query.filter_by(bc_id="C12345").all()
+            assert len(decs) == 1
+            assert decs[0].dec_id == "C12345.DEC.1"
+            assert decs[0].dec_label == "Systolic"
+
+    def test_edit_updates_existing_dec_fields(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", example_set="120", sort_order=0))
+            db.session.commit()
+        client.post(
+            "/bc/C12345/edit",
+            data={
+                "decs[0][dec_id]": "C12345.DEC.1",
+                "decs[0][dec_label]": "Systolic Blood Pressure",
+                "decs[0][data_type]": "decimal",
+                "decs[0][example_set]": "110-140",
+            },
+        )
+        with app.app_context():
+            decs = DataElementConcept.query.filter_by(bc_id="C12345").all()
+            assert len(decs) == 1
+            assert decs[0].dec_id == "C12345.DEC.1"
+            assert decs[0].dec_label == "Systolic Blood Pressure"
+            assert decs[0].example_set == "110-140"
+
+    def test_edit_adds_new_dec_row(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0))
+            db.session.commit()
+        client.post(
+            "/bc/C12345/edit",
+            data={
+                "decs[0][dec_id]": "C12345.DEC.1",
+                "decs[0][dec_label]": "Systolic",
+                "decs[0][data_type]": "decimal",
+                "decs[1][dec_label]": "Diastolic",
+                "decs[1][data_type]": "decimal",
+            },
+        )
+        with app.app_context():
+            decs = DataElementConcept.query.filter_by(bc_id="C12345").order_by(DataElementConcept.sort_order).all()
+            assert len(decs) == 2
+            assert decs[1].dec_label == "Diastolic"
+
+    def test_edit_removes_dec_omitted_from_submission(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add_all(
+                [
+                    DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0),
+                    DataElementConcept(dec_id="C12345.DEC.2", bc_id="C12345", dec_label="Diastolic", data_type="decimal", sort_order=1),
+                ]
+            )
+            db.session.commit()
+        client.post(
+            "/bc/C12345/edit",
+            data={
+                "decs[0][dec_id]": "C12345.DEC.1",
+                "decs[0][dec_label]": "Systolic",
+                "decs[0][data_type]": "decimal",
+            },
+        )
+        with app.app_context():
+            decs = DataElementConcept.query.filter_by(bc_id="C12345").all()
+            assert len(decs) == 1
+            assert decs[0].dec_label == "Systolic"
+
+    def test_edit_persists_required_flag(self, client, app, sample_bc):
+        client.post(
+            "/bc/C12345/edit",
+            data={
+                "decs[0][dec_label]": "Systolic",
+                "decs[0][data_type]": "decimal",
+                "decs[0][required]": "1",
+            },
+        )
+        with app.app_context():
+            dec = DataElementConcept.query.filter_by(bc_id="C12345").first()
+            assert dec.required is True
+
 
 # ---------------------------------------------------------------------------
 # POST /bc/<bc_id>/clear-ncit
@@ -552,15 +673,48 @@ class TestExport:
         assert r.status_code == 200
         assert r.content_type == "application/json"
 
+    def test_json_export_includes_decs(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0))
+            db.session.commit()
+        r = client.get("/bc/export?format=json")
+        parsed = json.loads(r.data)
+        bc = next(b for b in parsed if b["bc_id"] == "C12345")
+        assert bc["decs"][0]["dec_label"] == "Systolic"
+
     def test_xlsx_export(self, client, sample_bc):
         r = client.get("/bc/export?format=xlsx")
         assert r.status_code == 200
         assert "spreadsheetml" in r.content_type
 
+    def test_xlsx_export_matches_bc_lb_reference_format(self, client, app, sample_bc):
+        """The BC list's own export (not just the governance/published-only
+        export) must produce the files/BC Examples.xlsx BC_LB shape: a
+        BC-only row followed by one row per DEC."""
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0))
+            db.session.commit()
+        r = client.get("/bc/export?format=xlsx")
+        wb = openpyxl.load_workbook(io.BytesIO(r.data))
+        ws = wb.active
+        assert ws.title == "BC_LB"
+        headers = [c.value for c in ws[1]]
+        dec_label_col = headers.index("dec_label") + 1
+        assert ws.cell(row=2, column=dec_label_col).value in ("", None)
+        assert ws.cell(row=3, column=dec_label_col).value == "Systolic"
+
     def test_odm_xml_export(self, client, sample_bc):
         r = client.get("/bc/export?format=odm")
         assert r.status_code == 200
         assert "xml" in r.content_type
+
+    def test_odm_xml_export_includes_dec_item_def(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DataElementConcept(dec_id="C12345.DEC.1", bc_id="C12345", dec_label="Systolic", data_type="decimal", sort_order=0))
+            db.session.commit()
+        r = client.get("/bc/export?format=odm")
+        assert b'OID="C12345.DEC.1"' in r.data
+        assert b'Name="Systolic"' in r.data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bc_service.py
+++ b/tests/test_bc_service.py
@@ -2,8 +2,8 @@
 
 from extensions import db
 from models.audit import AuditLog
-from models.bc import BiomedicalConcept
-from services.bc_service import get_or_create_bc_stub
+from models.bc import BiomedicalConcept, DataElementConcept
+from services.bc_service import get_or_create_bc_stub, save_decs
 
 
 class TestGetOrCreateBcStub:
@@ -33,3 +33,42 @@ class TestGetOrCreateBcStub:
             db.session.commit()
             get_or_create_bc_stub(sample_bc, short_name="Ignored Name")
             assert AuditLog.query.count() == 0
+
+
+class TestSaveDecs:
+    def test_creates_decs_from_list(self, app, sample_bc):
+        with app.app_context():
+            save_decs(sample_bc, [{"dec_label": "Systolic", "data_type": "decimal", "example_set": "120", "required": True}])
+            decs = DataElementConcept.query.filter_by(bc_id=sample_bc).all()
+            assert len(decs) == 1
+            assert decs[0].dec_label == "Systolic"
+            assert decs[0].required is True
+            assert decs[0].dec_id == f"{sample_bc}.DEC.1"
+
+    def test_blank_label_rows_are_skipped_but_keep_position(self, app, sample_bc):
+        with app.app_context():
+            save_decs(sample_bc, [{"dec_label": ""}, {"dec_label": "Diastolic"}])
+            decs = DataElementConcept.query.filter_by(bc_id=sample_bc).all()
+            assert len(decs) == 1
+            assert decs[0].dec_id == f"{sample_bc}.DEC.2"
+
+    def test_replaces_existing_decs(self, app, sample_bc):
+        with app.app_context():
+            save_decs(sample_bc, [{"dec_label": "Old"}])
+            save_decs(sample_bc, [{"dec_label": "New"}])
+            decs = DataElementConcept.query.filter_by(bc_id=sample_bc).all()
+            assert len(decs) == 1
+            assert decs[0].dec_label == "New"
+
+    def test_empty_list_clears_all_decs(self, app, sample_bc):
+        with app.app_context():
+            save_decs(sample_bc, [{"dec_label": "Old"}])
+            save_decs(sample_bc, [])
+            assert DataElementConcept.query.filter_by(bc_id=sample_bc).count() == 0
+
+    def test_preserves_provided_dec_id_and_ncit_code(self, app, sample_bc):
+        with app.app_context():
+            save_decs(sample_bc, [{"dec_id": "CUSTOM.ID", "ncit_dec_code": "C999", "dec_label": "Systolic"}])
+            dec = DataElementConcept.query.filter_by(bc_id=sample_bc).first()
+            assert dec.dec_id == "CUSTOM.ID"
+            assert dec.ncit_dec_code == "C999"

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -9,12 +9,10 @@ from extensions import db
 from models.bc import BiomedicalConcept, DataElementConcept
 from models.specialization import DatasetSpecialization
 from services.export import (
-    BC_EXPORT_FIELDS,
     GOVERNANCE_HEADERS,
     export_governance_xlsx,
     export_json,
     export_odm_xml,
-    export_xlsx,
 )
 from services.ingestion import VARIABLE_FIELDS, parse_xlsx
 
@@ -70,40 +68,6 @@ class TestExportJson:
 
         out = export_json([{"bc_id": "X", "created_at": datetime(2026, 1, 1)}])
         assert "2026-01-01" in out
-
-
-class TestExportXlsx:
-    def test_returns_workbook_with_headers_and_rows(self):
-        buf = export_xlsx(SAMPLE_BCS)
-        wb = openpyxl.load_workbook(buf)
-        ws = wb.active
-        assert ws.title == "Biomedical Concepts"
-        headers = [c.value for c in ws[1]]
-        assert headers[0] == "Bc Id"
-        assert len(headers) == len(BC_EXPORT_FIELDS)
-        # Row 2 = first BC
-        assert ws.cell(row=2, column=1).value == "C64849"
-        assert ws.cell(row=3, column=2).value == "Systolic Blood Pressure"
-
-    def test_empty_list_has_header_only(self):
-        wb = openpyxl.load_workbook(export_xlsx([]))
-        ws = wb.active
-        assert ws.max_row == 1
-
-    def test_missing_fields_render_blank(self):
-        wb = openpyxl.load_workbook(export_xlsx([{"bc_id": "ONLY_ID"}]))
-        ws = wb.active
-        assert ws.cell(row=2, column=1).value == "ONLY_ID"
-        assert ws.cell(row=2, column=2).value in ("", None)
-
-    def test_code_column_uses_loinc_code(self):
-        """BiomedicalConcept.to_dict() has no 'code' key (only 'loinc_code'),
-        so the 'Code' column must be sourced from 'loinc_code'."""
-        wb = openpyxl.load_workbook(export_xlsx(SAMPLE_BCS))
-        ws = wb.active
-        code_col = BC_EXPORT_FIELDS.index("code") + 1
-        assert ws.cell(row=2, column=code_col).value == "4548-4"
-        assert ws.cell(row=3, column=code_col).value in ("", None)
 
 
 class TestExportGovernanceXlsx:
@@ -162,6 +126,42 @@ class TestExportGovernanceXlsx:
         assert ws.cell(row=3, column=bc_id_col).value == "C64849"
         # History of Change lands in the last column
         assert ws.cell(row=2, column=len(GOVERNANCE_HEADERS)).value == "Initial version"
+
+    def test_ncit_dec_code_column_mirrors_dec_id(self, app):
+        """Column N (ncit_dec_code) must always mirror column M (dec_id) on
+        export — the DEC ID field is the only identifier curators can set
+        through the UI, so the legacy ncit_dec_code column is populated from
+        it rather than the (now unused) stored value."""
+        with app.app_context():
+            bc = self._make_bc_with_decs()
+            wb = openpyxl.load_workbook(export_governance_xlsx([bc]))
+        ws = wb.active
+        dec_id_col = GOVERNANCE_HEADERS.index("dec_id") + 1
+        ncit_dec_code_col = GOVERNANCE_HEADERS.index("ncit_dec_code") + 1
+        for row in (3, 4):
+            assert ws.cell(row=row, column=ncit_dec_code_col).value == ws.cell(row=row, column=dec_id_col).value
+
+    def test_ncit_dec_code_column_overrides_a_stored_distinct_value(self, app):
+        with app.app_context():
+            bc = BiomedicalConcept(bc_id="C111", short_name="X", status="provisional")
+            db.session.add(bc)
+            db.session.add(
+                DataElementConcept(
+                    dec_id="C111.DEC.1",
+                    bc_id="C111",
+                    ncit_dec_code="SOME_OTHER_CODE",
+                    dec_label="Label",
+                    data_type="string",
+                    sort_order=0,
+                )
+            )
+            db.session.commit()
+            wb = openpyxl.load_workbook(export_governance_xlsx([bc]))
+        ws = wb.active
+        dec_id_col = GOVERNANCE_HEADERS.index("dec_id") + 1
+        ncit_dec_code_col = GOVERNANCE_HEADERS.index("ncit_dec_code") + 1
+        assert ws.cell(row=3, column=dec_id_col).value == "C111.DEC.1"
+        assert ws.cell(row=3, column=ncit_dec_code_col).value == "C111.DEC.1"
 
     def test_bc_without_loinc_blanks_system_fields(self, app):
         with app.app_context():
@@ -311,3 +311,30 @@ class TestExportOdmXml:
     def test_empty_list(self):
         root = etree.fromstring(export_odm_xml([]).encode())
         assert len(root) == 0
+
+    def test_decs_emit_item_defs(self):
+        bcs_with_dec = [
+            {
+                **SAMPLE_BCS[0],
+                "decs": [
+                    {"dec_id": "C64849.DEC.1", "ncit_dec_code": "C999", "dec_label": "Result Value", "data_type": "decimal", "example_set": "", "required": False},
+                ],
+            }
+        ]
+        xml = export_odm_xml(bcs_with_dec)
+        root = etree.fromstring(xml.encode())
+        ns = {"odm": "http://www.cdisc.org/ns/odm/v1.3"}
+        item_defs = root.findall("odm:ItemDef", ns)
+        assert len(item_defs) == 2
+        dec_item = next(i for i in item_defs if i.get("OID") == "C64849.DEC.1")
+        assert dec_item.get("Name") == "Result Value"
+        assert dec_item.get("DataType") == "float"
+        alias = dec_item.find("odm:Alias", ns)
+        assert alias.get("Name") == "C999"
+
+    def test_bc_without_decs_key_emits_no_extra_item_defs(self):
+        xml = export_odm_xml(SAMPLE_BCS)
+        root = etree.fromstring(xml.encode())
+        ns = {"odm": "http://www.cdisc.org/ns/odm/v1.3"}
+        item_defs = root.findall("odm:ItemDef", ns)
+        assert len(item_defs) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 
 from extensions import db
 from models.audit import AuditLog
-from models.bc import RESULT_SCALES, BiomedicalConcept, partition_result_scales, split_result_scales
+from models.bc import RESULT_SCALES, BiomedicalConcept, DataElementConcept, partition_result_scales, split_result_scales
 from models.ingestion import IngestionRecord
 
 
@@ -114,6 +114,27 @@ class TestBiomedicalConceptToDict:
             db.session.add(bc)
             db.session.commit()
             assert bc.status == "provisional"
+
+    def test_to_dict_includes_decs_in_sort_order(self, app):
+        with app.app_context():
+            bc = BiomedicalConcept(bc_id="C004", short_name="BP", definition="Blood Pressure")
+            db.session.add(bc)
+            db.session.add_all(
+                [
+                    DataElementConcept(dec_id="C004.DEC.2", bc_id="C004", dec_label="Diastolic", data_type="decimal", sort_order=1),
+                    DataElementConcept(dec_id="C004.DEC.1", bc_id="C004", dec_label="Systolic", data_type="decimal", sort_order=0),
+                ]
+            )
+            db.session.commit()
+            decs = bc.to_dict()["decs"]
+            assert [d["dec_label"] for d in decs] == ["Systolic", "Diastolic"]
+
+    def test_to_dict_decs_empty_when_none(self, app):
+        with app.app_context():
+            bc = BiomedicalConcept(bc_id="C005", short_name="X", definition="Y")
+            db.session.add(bc)
+            db.session.commit()
+            assert bc.to_dict()["decs"] == []
 
 
 class TestResultScales:


### PR DESCRIPTION
## Summary

- Fixed a form-field-naming mismatch (`decs[N][field]` vs. legacy `dec_label[]` arrays) that caused every BC save to delete all Data Element Concepts (DECs) and add none back.
- Added hidden `dec_id`/`ncit_dec_code` inputs so editing an existing DEC preserves its identity instead of it being silently regenerated, and persisted the `required` checkbox (previously discarded).
- Added a visible, editable **DEC ID** field to the DEC table, positioned before **DEC Label**.
- Pointed `/bc/export?format=xlsx` at the reference-format-matching `export_governance_xlsx` (BC row + one row per DEC, matching `files/BC Examples.xlsx`'s `BC_LB`/`BC_VS` sheet shape) instead of the old DEC-blind exporter, which has been removed.
- Included DEC data in JSON export (`BiomedicalConcept.to_dict()`) and ODM-XML export (one `ItemDef` per DEC).
- Made the exported `ncit_dec_code` column (column N) always mirror the `dec_id` column (column M), per follow-up request — an export-time transformation, not a change to stored data.

## Test plan

- [x] Wrote tests first (TDD) for every change above
- [x] `pytest` — full suite passing (361 tests)
- [x] `isort`/`black`/`flake8` clean
- [x] Verified end-to-end against a live dev server on a throwaway DB: create BC with DECs, edit (update/add/remove DEC rows) in one save, confirm JSON/XLSX/ODM exports all carry correct DEC data and column M/N match in the XLSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)