### PR TITLE
Fix Export CSV/JSON buttons on the audit trail page

### DIFF
--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -30,6 +30,12 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 
 ### 2026-09-01
 
+#### Fixed Export CSV/JSON Buttons on the Audit Trail Page
+
+- The "Export CSV" and "Export JSON" buttons on `/audit/` appended `?export=csv`/`?export=json` to the URL, but `routes/audit.py`'s `index()` never read that parameter — it just re-rendered the same filtered HTML page, so clicking either button silently did nothing.
+- `routes/audit.py` — extracted the existing filter-building logic into `_filtered_query()`; `index()` now checks `request.args.get("export")` and, when set to `csv` or `json`, returns the full filtered (unpaginated) result set as a download via Flask `Response` (`text/csv` / `application/json`, `Content-Disposition: attachment; filename=audit_log.{csv,json}`), matching the existing export pattern in `routes/bc.py`. Added `_log_to_dict()` and `_export_csv()`/`_export_json()` helpers; `before_state`/`after_state` are JSON-serialized in the CSV and left as nested objects in the JSON export.
+- Wrote tests first (TDD): `TestAuditExportCSV` and `TestAuditExportJSON` in `tests/test_audit_routes.py` cover attachment headers/mimetypes, row/record content, filter pass-through (`entity_type`, `actor`), and exporting past the 50-row pagination limit (60 rows in, 60 rows out); 368 tests passing, isort/black/flake8 clean ✅
+
 #### Made the ncit_dec_code Export Column Mirror dec_id
 
 - In the exported `BC_LB`/`BC_VS` xlsx sheet, column M (`dec_id`) was populated correctly but column N (`ncit_dec_code`) was left at whatever was stored on the DEC (typically blank, since the BC detail form no longer exposes it as a separate field — see the DEC ID entry below). Made the export always populate column N with the same value as column M.

--- a/routes/audit.py
+++ b/routes/audit.py
@@ -1,6 +1,9 @@
+import csv
+import io
+import json
 import logging
 
-from flask import Blueprint, render_template, request
+from flask import Blueprint, Response, render_template, request
 
 from models.audit import AuditLog
 
@@ -8,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 bp = Blueprint("audit", __name__)
 
+EXPORT_COLUMNS = ["id", "timestamp", "entity_type", "entity_id", "action", "actor", "before_state", "after_state"]
 
-@bp.route("/")
-def index():
-    page = request.args.get("page", 1, type=int)
+
+def _filtered_query():
     entity_type = request.args.get("entity_type", "")
     action = request.args.get("action", "")
     actor = request.args.get("actor", "")
@@ -29,8 +32,61 @@ def index():
         query = query.filter(AuditLog.timestamp >= date_from)
     if date_to:
         query = query.filter(AuditLog.timestamp <= date_to)
+    return query
 
-    logs = query.order_by(AuditLog.timestamp.desc()).paginate(page=page, per_page=50, error_out=False)
+
+def _log_to_dict(log):
+    return {
+        "id": log.id,
+        "timestamp": log.timestamp.isoformat() if log.timestamp else None,
+        "entity_type": log.entity_type,
+        "entity_id": log.entity_id,
+        "action": log.action,
+        "actor": log.actor,
+        "before_state": log.before_state,
+        "after_state": log.after_state,
+    }
+
+
+def _export_csv(logs):
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=EXPORT_COLUMNS)
+    writer.writeheader()
+    for log in logs:
+        row = _log_to_dict(log)
+        row["before_state"] = json.dumps(row["before_state"]) if row["before_state"] is not None else ""
+        row["after_state"] = json.dumps(row["after_state"]) if row["after_state"] is not None else ""
+        writer.writerow(row)
+    return Response(
+        buf.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=audit_log.csv"},
+    )
+
+
+def _export_json(logs):
+    return Response(
+        json.dumps([_log_to_dict(log) for log in logs], indent=2),
+        mimetype="application/json",
+        headers={"Content-Disposition": "attachment; filename=audit_log.json"},
+    )
+
+
+@bp.route("/")
+def index():
+    page = request.args.get("page", 1, type=int)
+    entity_type = request.args.get("entity_type", "")
+    action = request.args.get("action", "")
+    actor = request.args.get("actor", "")
+    date_from = request.args.get("date_from", "")
+    date_to = request.args.get("date_to", "")
+
+    export_format = request.args.get("export", "")
+    if export_format in ("csv", "json"):
+        logs = _filtered_query().order_by(AuditLog.timestamp.desc()).all()
+        return _export_csv(logs) if export_format == "csv" else _export_json(logs)
+
+    logs = _filtered_query().order_by(AuditLog.timestamp.desc()).paginate(page=page, per_page=50, error_out=False)
     return render_template(
         "audit.html",
         audit_logs=logs,

--- a/tests/test_audit_routes.py
+++ b/tests/test_audit_routes.py
@@ -1,5 +1,9 @@
 """Tests for routes/audit.py — log listing and filtering."""
 
+import csv
+import io
+import json
+
 from extensions import db
 from models.audit import AuditLog
 
@@ -47,3 +51,63 @@ class TestAuditIndex:
         _add_log(app)
         r = client.get("/audit/?page=1")
         assert r.status_code == 200
+
+
+class TestAuditExportCSV:
+    def test_returns_csv_attachment(self, client, app):
+        _add_log(app, entity_id="C001", action="created", actor="alice")
+        r = client.get("/audit/?export=csv")
+        assert r.status_code == 200
+        assert r.mimetype == "text/csv"
+        assert "attachment" in r.headers["Content-Disposition"]
+        assert "audit_log.csv" in r.headers["Content-Disposition"]
+
+    def test_csv_contains_rows(self, client, app):
+        _add_log(app, entity_id="C001", action="created", actor="alice")
+        _add_log(app, entity_id="C002", action="deleted", actor="bob")
+        r = client.get("/audit/?export=csv")
+        rows = list(csv.reader(io.StringIO(r.get_data(as_text=True))))
+        header, *data_rows = rows
+        assert "entity_id" in header
+        entity_ids = [row[header.index("entity_id")] for row in data_rows]
+        assert "C001" in entity_ids
+        assert "C002" in entity_ids
+
+    def test_csv_respects_filters(self, client, app):
+        _add_log(app, entity_type="BiomedicalConcept", entity_id="C001")
+        _add_log(app, entity_type="GovernanceRecord", entity_id="G001")
+        r = client.get("/audit/?export=csv&entity_type=BiomedicalConcept")
+        text = r.get_data(as_text=True)
+        assert "C001" in text
+        assert "G001" not in text
+
+    def test_csv_exports_beyond_one_page(self, client, app):
+        for i in range(60):
+            _add_log(app, entity_id=f"C{i:03d}")
+        r = client.get("/audit/?export=csv")
+        rows = list(csv.reader(io.StringIO(r.get_data(as_text=True))))
+        assert len(rows) - 1 == 60
+
+
+class TestAuditExportJSON:
+    def test_returns_json_attachment(self, client, app):
+        _add_log(app, entity_id="C001")
+        r = client.get("/audit/?export=json")
+        assert r.status_code == 200
+        assert r.mimetype == "application/json"
+        assert "attachment" in r.headers["Content-Disposition"]
+        assert "audit_log.json" in r.headers["Content-Disposition"]
+
+    def test_json_contains_records(self, client, app):
+        _add_log(app, entity_id="C001", action="created", actor="alice")
+        r = client.get("/audit/?export=json")
+        data = json.loads(r.get_data(as_text=True))
+        assert isinstance(data, list)
+        assert any(rec["entity_id"] == "C001" and rec["actor"] == "alice" for rec in data)
+
+    def test_json_respects_filters(self, client, app):
+        _add_log(app, actor="alice", entity_id="C001")
+        _add_log(app, actor="bob", entity_id="C002")
+        r = client.get("/audit/?export=json&actor=alice")
+        data = json.loads(r.get_data(as_text=True))
+        assert {rec["entity_id"] for rec in data} == {"C001"}


### PR DESCRIPTION
## Summary
- The Export CSV/JSON buttons on `/audit/` appended `?export=csv`/`?export=json` to the URL, but `routes/audit.py`'s `index()` never checked that parameter and just re-rendered the same filtered HTML page, so the buttons silently did nothing.
- `index()` now returns a downloadable CSV/JSON attachment of the full filtered (unpaginated) result set when `export=csv`/`export=json` is present, following the same `Response`/`Content-Disposition` pattern already used in `routes/bc.py`.

## Test plan
- [x] Added `TestAuditExportCSV`/`TestAuditExportJSON` in `tests/test_audit_routes.py` covering attachment headers/mimetypes, row/record content, filter pass-through, and exporting beyond the 50-row pagination limit
- [x] `pytest --tb=short` — 368 passed
- [x] isort/black/flake8 clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)