### PR TITLE
Add pyproject.toml project metadata, sync supported Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Flask web application for curating CDISC Biomedical Concepts (BCs). It replace
 
 ## Prerequisites
 
-- Python 3.10 or later
+- Python 3.11 or later
 - pip
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
+[project]
+name = "cdisc-concept-curation"
+version = "0.4.0"
+description = "Flask web application for curating CDISC Biomedical Concepts (BCs)"
+requires-python = ">=3.11"
+
 [tool.black]
 line-length = 200
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py311', 'py312']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- Added a `[project]` table to `pyproject.toml` (name, version 0.4.0, description, `requires-python = ">=3.11"`)
- Updated `[tool.black] target-version` from `['py39', 'py310', 'py311']` to `['py311', 'py312']` to match the CI matrix in `.github/workflows/ci.yml`
- Updated `README.md` prerequisite from "Python 3.10 or later" to "Python 3.11 or later" to match

## Test plan
- [x] `black --check .` and `isort --check-only .` pass
- [x] `pytest` (via pre-commit hook) passes