### PR TITLE
Lock editing and enable Reject at Ready to Publish status

### DIFF
--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -30,6 +30,15 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 
 ### 2026-09-01
 
+#### Locked Editing and Added Reject at "Ready to Publish" Status
+
+- Governance stages run `provisional → sme_review → cdisc_approval → published`; the `published` stage is labeled "Ready to Publish" on the Governance Kanban board (`templates/governance.html`) but was inconsistently labeled "Published" everywhere else, and nothing in the app treated it as a terminal, locked state — every BC/specialization edit and delete route worked identically regardless of status.
+- `services/bc_service.py` — `update_bc()` and `map_ncit_to_bc()` now raise `ValueError` when the BC is already `published`; this guard is inherited automatically by the MCP `update_bc`/`map_ncit_to_bc` tools since they call the same functions.
+- `routes/bc.py` — `edit()`, `clear_ncit()`, `clear_loinc()`, and `delete()` now refuse the action (flash + redirect) for a published BC; `routes/ncit.py` `resolve()` catches the new `ValueError`; `routes/specializations.py`'s upsert route (update branch only, not create) and `delete()` refuse the action for a published specialization.
+- The Governance board's `published`/"Ready to Publish" Kanban column previously rendered no action buttons at all, so there was no way to reject an item once it reached that column even though `reject_bc`/`reject_specialization` already worked unconditionally from any status — added a Reject button there for both BCs and specs, reusing the existing `kanban-reject-btn` JS wiring and routes.
+- `templates/bc_detail.html` and `templates/specializations.html` now show a locked notice and wrap their editable fields in a disabled `<fieldset>` when `published`; `templates/bc_list.html` and `templates/specializations.html` disable the row Delete button for published items; relabeled `published` as "Ready to Publish" consistently across `bc_detail.html`, `bc_list.html`, and `specializations.html` to match the Kanban board.
+- Wrote tests first (TDD) covering every new guard across `tests/test_bc_routes.py`, `tests/test_specializations_routes.py`, `tests/test_ncit.py`, `tests/test_governance_routes.py`, and `tests/test_mcp_server.py`; manually verified end-to-end against a running server (create → advance through all 4 stages → edit/delete blocked → reject via the new board button → edit/delete work again) for both a BC and a specialization; 383 tests passing, isort/black/flake8 clean ✅
+
 #### Fixed Export CSV/JSON Buttons on the Audit Trail Page
 
 - The "Export CSV" and "Export JSON" buttons on `/audit/` appended `?export=csv`/`?export=json` to the URL, but `routes/audit.py`'s `index()` never read that parameter — it just re-rendered the same filtered HTML page, so clicking either button silently did nothing.

--- a/routes/bc.py
+++ b/routes/bc.py
@@ -220,7 +220,11 @@ def edit(bc_id):
     # on the real edit form) disambiguates "clear it" from "leave it alone".
     if "result_scales_submitted" in request.form:
         data["result_scales"] = "; ".join(request.form.getlist("result_scales"))
-    bc_service.update_bc(bc_id, data, actor="user")
+    try:
+        bc_service.update_bc(bc_id, data, actor="user")
+    except ValueError as e:
+        flash(str(e), "danger")
+        return redirect(url_for("bc.detail", bc_id=bc_id))
     bc_service.save_decs(bc_id, _decs_from_form(request.form))
     flash(f"BC {bc_id} updated", "success")
     return redirect(url_for("bc.detail", bc_id=bc_id))
@@ -229,6 +233,9 @@ def edit(bc_id):
 @bp.route("/<bc_id>/clear-ncit", methods=["POST"])
 def clear_ncit(bc_id):
     bc = db.get_or_404(BiomedicalConcept, bc_id)
+    if bc.status == "published":
+        flash(f"BC {bc_id} has reached Ready to Publish status and cannot be edited", "danger")
+        return redirect(url_for("bc.detail", bc_id=bc_id))
     before = bc.to_dict()
     bc.ncit_code = None
     bc.ncit_metadata = None
@@ -243,6 +250,9 @@ def clear_ncit(bc_id):
 @bp.route("/<bc_id>/clear-loinc", methods=["POST"])
 def clear_loinc(bc_id):
     bc = db.get_or_404(BiomedicalConcept, bc_id)
+    if bc.status == "published":
+        flash(f"BC {bc_id} has reached Ready to Publish status and cannot be edited", "danger")
+        return redirect(url_for("bc.detail", bc_id=bc_id))
     before = bc.to_dict()
     bc.loinc_code = None
     bc.loinc_metadata = None
@@ -266,6 +276,9 @@ def submit_for_review(bc_id):
 @bp.route("/<bc_id>/delete", methods=["POST"])
 def delete(bc_id):
     bc = db.get_or_404(BiomedicalConcept, bc_id)
+    if bc.status == "published":
+        flash(f"BC {bc_id} has reached Ready to Publish status and cannot be deleted", "danger")
+        return redirect(url_for("bc.detail", bc_id=bc_id))
     # Nullify self-referential parent FK on child BCs; without this SQLAlchemy
     # raises CircularDependencyError when flushing the delete.
     BiomedicalConcept.query.filter_by(parent_bc_id=bc_id).update({"parent_bc_id": None}, synchronize_session="fetch")

--- a/routes/ncit.py
+++ b/routes/ncit.py
@@ -78,6 +78,10 @@ def resolve(bc_id):
     bc = db.get_or_404(BiomedicalConcept, bc_id)
     ncit_code = request.form.get("ncit_code", "").strip()
     if ncit_code:
-        bc = bc_service.map_ncit_to_bc(bc_id, ncit_code, actor="user")
+        try:
+            bc = bc_service.map_ncit_to_bc(bc_id, ncit_code, actor="user")
+        except ValueError as e:
+            flash(str(e), "danger")
+            return redirect(url_for("ncit.mapping"))
         flash(f"NCIt mapping updated for {bc.short_name}", "success")
     return redirect(url_for("ncit.mapping"))

--- a/routes/specializations.py
+++ b/routes/specializations.py
@@ -122,6 +122,9 @@ def create():
 
     spec = db.session.get(DatasetSpecialization, vlm_group_id)
     if spec:
+        if spec.status == "published":
+            flash(f"Specialization {vlm_group_id} has reached Ready to Publish status and cannot be edited", "danger")
+            return redirect(url_for("specializations.index"))
         before = spec.to_dict()
         spec.bc_id = bc_id
         spec.domain = domain
@@ -149,6 +152,9 @@ def create():
 @bp.route("/<vlm_group_id>/delete", methods=["POST"])
 def delete(vlm_group_id):
     spec = db.get_or_404(DatasetSpecialization, vlm_group_id)
+    if spec.status == "published":
+        flash(f"Specialization {vlm_group_id} has reached Ready to Publish status and cannot be deleted", "danger")
+        return redirect(url_for("specializations.index"))
     log_change("DatasetSpecialization", vlm_group_id, "deleted", actor="user", before=spec.to_dict())
     db.session.delete(spec)
     db.session.commit()

--- a/services/bc_service.py
+++ b/services/bc_service.py
@@ -98,6 +98,8 @@ def get_or_create_bc_stub(bc_id, short_name="", actor=None):
 def update_bc(bc_id, data, actor="user"):
     """Update an existing BC from a dict of fields. Returns the BC."""
     bc = _get_bc_or_raise(bc_id)
+    if bc.status == "published":
+        raise ValueError(f"BC {bc_id} has reached Ready to Publish status and cannot be edited")
     before = bc.to_dict()
     apply_bc_fields(bc, data, is_new=False)
     log_change("BiomedicalConcept", bc_id, "updated", actor=actor, before=before, after=bc.to_dict())
@@ -142,6 +144,8 @@ def map_ncit_to_bc(bc_id, ncit_code, actor="user"):
     if not ncit_code:
         raise ValueError("ncit_code is required")
     bc = _get_bc_or_raise(bc_id)
+    if bc.status == "published":
+        raise ValueError(f"BC {bc_id} has reached Ready to Publish status and cannot be edited")
     before = bc.to_dict()
     bc.ncit_code = ncit_code
     # Promote temporary IMPORT_ IDs to their resolved NCIt code

--- a/templates/bc_detail.html
+++ b/templates/bc_detail.html
@@ -21,7 +21,7 @@
     {% elif bc.status == 'cdisc_approval' %}
       <span class="bc-badge bc-badge-cdisc-approval">CDISC Approval</span>
     {% elif bc.status == 'published' %}
-      <span class="bc-badge bc-badge-published">Published</span>
+      <span class="bc-badge bc-badge-published">Ready to Publish</span>
     {% endif %}
     {% if bc.submitter %}
       <span class="page-meta">Submitted by {{ bc.submitter }}</span>
@@ -49,6 +49,15 @@
       novalidate>
   {{ form.hidden_tag() if form else '' }}
 
+  {% if not is_new and bc.status == 'published' %}
+  <div class="alert alert-secondary d-flex align-items-center gap-2" role="alert">
+    <i class="bi bi-lock" aria-hidden="true"></i>
+    This concept has reached Ready to Publish status and can no longer be edited. Reject it from the
+    <a href="{{ url_for('governance.board') }}">Governance Board</a> to resume editing.
+  </div>
+  {% endif %}
+
+  <fieldset {% if not is_new and bc.status == 'published' %}disabled{% endif %}>
   <div class="two-col-grid">
 
     <!-- Left column: BC fields + DECs -->
@@ -325,7 +334,7 @@
           {% elif bc.status == 'cdisc_approval' %}
             <span class="bc-badge bc-badge-cdisc-approval">CDISC Approval</span>
           {% elif bc.status == 'published' %}
-            <span class="bc-badge bc-badge-published">Published</span>
+            <span class="bc-badge bc-badge-published">Ready to Publish</span>
           {% endif %}
           <input type="hidden" name="status" value="{{ bc.status if bc else 'provisional' }}">
         </div>
@@ -334,9 +343,13 @@
 
       <!-- Form submit buttons -->
       <div class="d-flex gap-2 mt-3 flex-wrap">
+        {% if not is_new and bc.status == 'published' %}
+        <span class="text-secondary small fst-italic">Read-only — Ready to Publish</span>
+        {% else %}
         <button type="submit" name="action" value="save" class="btn btn-primary btn-sm">
           <i class="bi bi-floppy" aria-hidden="true"></i> Save
         </button>
+        {% endif %}
         <a href="{{ url_for('bc.index') }}" class="btn btn-sm btn-outline-secondary">Cancel</a>
       </div>
 
@@ -458,6 +471,7 @@
     </div><!-- /right column -->
 
   </div><!-- /two-col-grid -->
+  </fieldset>
 </form>
 {% if bc and bc.bc_id %}
 {% if bc.ncit_code %}

--- a/templates/bc_list.html
+++ b/templates/bc_list.html
@@ -58,7 +58,7 @@
       <option value="provisional"     {% if request.args.get('status') == 'provisional'     %}selected{% endif %}>Provisional</option>
       <option value="sme_review"      {% if request.args.get('status') == 'sme_review'      %}selected{% endif %}>SME Review</option>
       <option value="cdisc_approval"  {% if request.args.get('status') == 'cdisc_approval'  %}selected{% endif %}>CDISC Approval</option>
-      <option value="published"       {% if request.args.get('status') == 'published'       %}selected{% endif %}>Published</option>
+      <option value="published"       {% if request.args.get('status') == 'published'       %}selected{% endif %}>Ready to Publish</option>
     </select>
 
     <select name="category" class="form-select form-select-sm" style="width: auto;"
@@ -119,7 +119,7 @@
               {% elif bc.status == 'cdisc_approval' %}
                 <span class="bc-badge bc-badge-cdisc-approval">CDISC Approval</span>
               {% elif bc.status == 'published' %}
-                <span class="bc-badge bc-badge-published">Published</span>
+                <span class="bc-badge bc-badge-published">Ready to Publish</span>
               {% else %}
                 <span class="bc-badge bc-badge-new">{{ bc.status | default('—') }}</span>
               {% endif %}
@@ -134,10 +134,15 @@
                 </a>
                 <button type="button"
                         class="btn btn-sm btn-outline-danger"
+                        {% if bc.status == 'published' %}
+                        disabled
+                        title="Ready to Publish concepts cannot be deleted"
+                        {% else %}
                         data-bs-toggle="modal"
                         data-bs-target="#delete-confirm-modal"
                         data-bc-name="{{ bc.short_name | e }}"
                         data-delete-url="{{ url_for('bc.delete', bc_id=bc.bc_id) }}"
+                        {% endif %}
                         aria-label="Delete {{ bc.short_name }}">
                   <i class="bi bi-trash" aria-hidden="true"></i>
                 </button>

--- a/templates/governance.html
+++ b/templates/governance.html
@@ -194,6 +194,14 @@
             {% if bc.package_date %} &middot; Published {{ bc.package_date }}{% endif %}
           </div>
           <span class="bc-badge bc-badge-published">Ready to Publish</span>
+          <div class="kanban-card-actions">
+            <button type="button"
+                    class="btn btn-sm btn-outline-danger kanban-reject-btn"
+                    data-bc-id="{{ bc.bc_id }}"
+                    aria-label="Reject {{ bc.short_name }}">
+              <i class="bi bi-x" aria-hidden="true"></i> Reject
+            </button>
+          </div>
         </div>
         {% endfor %}
       {% else %}
@@ -371,6 +379,14 @@
             {% if spec.bc %} &middot; {{ spec.bc.short_name }}{% endif %}
           </div>
           <span class="bc-badge bc-badge-published">Ready to Publish</span>
+          <div class="kanban-card-actions">
+            <button type="button"
+                    class="btn btn-sm btn-outline-danger kanban-reject-btn"
+                    data-vlm-group-id="{{ spec.vlm_group_id }}"
+                    aria-label="Reject {{ spec.short_name }}">
+              <i class="bi bi-x" aria-hidden="true"></i> Reject
+            </button>
+          </div>
         </div>
         {% endfor %}
       {% else %}

--- a/templates/specializations.html
+++ b/templates/specializations.html
@@ -30,6 +30,16 @@
           novalidate>
       {{ form.hidden_tag() if form else '' }}
 
+      {% if edit_spec and edit_spec.status == 'published' %}
+      <div class="alert alert-secondary d-flex align-items-center gap-2" role="alert">
+        <i class="bi bi-lock" aria-hidden="true"></i>
+        This specialization has reached Ready to Publish status and can no longer be edited. Reject it
+        from the <a href="{{ url_for('governance.board') }}">Governance Board</a> to resume editing.
+      </div>
+      {% endif %}
+
+      <fieldset {% if edit_spec and edit_spec.status == 'published' %}disabled{% endif %}>
+
       <div class="row g-3 mb-3">
         <div class="col-md-4">
           <label for="vlm_group_id" class="form-label small fw-semibold">VLM Group ID <span class="text-danger" aria-hidden="true">*</span></label>
@@ -145,6 +155,10 @@
         <button type="button" id="add-spec-var-btn" class="btn btn-sm btn-outline-secondary">
           <i class="bi bi-plus-lg" aria-hidden="true"></i> Add Variable Row
         </button>
+      </div>
+      </fieldset>
+
+      <div class="d-flex gap-2 flex-wrap mt-2">
         <button type="button" class="btn btn-sm btn-outline-secondary"
                 data-bs-toggle="collapse" data-bs-target="#specialization-form-panel">
           Cancel
@@ -154,6 +168,7 @@
   </div>
 </div>
 
+{% if not edit_spec %}
 <!-- Specializations list table -->
 <div class="bc-card">
   <div class="bc-card-header">
@@ -192,7 +207,7 @@
             {{ vcount }} variable{{ 's' if vcount != 1 else '' }}
           </td>
           <td>
-            {% set status_labels = {"provisional": "Provisional", "sme_review": "SME Review", "cdisc_approval": "CDISC Approval", "published": "Published"} %}
+            {% set status_labels = {"provisional": "Provisional", "sme_review": "SME Review", "cdisc_approval": "CDISC Approval", "published": "Ready to Publish"} %}
             <span class="bc-badge bc-badge-{{ (spec.status or 'provisional') | replace('_', '-') }}">
               {{ status_labels.get(spec.status, (spec.status or 'provisional') | replace('_', ' ') | title) }}
             </span>
@@ -209,6 +224,7 @@
                     style="display:inline;">
                 {{ form.hidden_tag() if form else '' }}
                 <button type="submit" class="btn btn-sm btn-outline-danger"
+                        {% if spec.status == 'published' %}disabled title="Ready to Publish specializations cannot be deleted"{% endif %}
                         aria-label="Delete {{ spec.short_name }}">
                   <i class="bi bi-trash" aria-hidden="true"></i>
                 </button>
@@ -230,6 +246,7 @@
   </div>
   {% endif %}
 </div>
+{% endif %}
 
 {% endblock %}
 

--- a/tests/test_bc_routes.py
+++ b/tests/test_bc_routes.py
@@ -311,6 +311,18 @@ class TestEditBc:
         r = client.post("/bc/NOPE/edit", data={"short_name": "X"})
         assert r.status_code == 404
 
+    def test_edit_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            bc.status = "published"
+            db.session.commit()
+        r = client.post("/bc/C12345/edit", data={"short_name": "Updated Name"}, follow_redirects=True)
+        assert r.status_code == 200
+        assert b"Ready to Publish" in r.data
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.short_name == "Test Concept"
+
     def test_edit_updates_result_scales_when_marker_present(self, client, app, sample_bc):
         client.post(
             "/bc/C12345/edit",
@@ -564,6 +576,18 @@ class TestClearNcitCode:
         r = client.post("/bc/NOTREAL/clear-ncit")
         assert r.status_code == 404
 
+    def test_clear_ncit_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            bc.status = "published"
+            db.session.commit()
+        r = client.post("/bc/C12345/clear-ncit", follow_redirects=True)
+        assert r.status_code == 200
+        assert b"Ready to Publish" in r.data
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.ncit_code == "C12345"
+
     def test_clear_ncit_also_clears_parent_bc_id(self, client, app, sample_bc):
         with app.app_context():
             bc = db.session.get(BiomedicalConcept, "C12345")
@@ -620,6 +644,19 @@ class TestClearLoincCode:
         r = client.post("/bc/NOTREAL/clear-loinc")
         assert r.status_code == 404
 
+    def test_clear_loinc_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            bc.loinc_code = "4548-4"
+            bc.status = "published"
+            db.session.commit()
+        r = client.post("/bc/C12345/clear-loinc", follow_redirects=True)
+        assert r.status_code == 200
+        assert b"Ready to Publish" in r.data
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.loinc_code == "4548-4"
+
 
 # ---------------------------------------------------------------------------
 # POST /bc/<bc_id>/submit
@@ -660,6 +697,17 @@ class TestDeleteBc:
     def test_nonexistent_bc_returns_404(self, client):
         r = client.post("/bc/NOPE/delete")
         assert r.status_code == 404
+
+    def test_delete_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            bc.status = "published"
+            db.session.commit()
+        r = client.post("/bc/C12345/delete", follow_redirects=True)
+        assert r.status_code == 200
+        assert b"Ready to Publish" in r.data
+        with app.app_context():
+            assert db.session.get(BiomedicalConcept, "C12345") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_governance_routes.py
+++ b/tests/test_governance_routes.py
@@ -108,6 +108,21 @@ class TestReject:
         r = client.post("/governance/reject/NOPE")
         assert r.status_code == 404
 
+    def test_reject_from_published_returns_to_provisional(self, client, app, sample_bc):
+        for _ in range(3):
+            client.post("/governance/advance/C12345")
+        client.post("/governance/reject/C12345")
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.status == "provisional"
+
+    def test_board_shows_reject_button_for_published_bc(self, client, app, sample_bc):
+        for _ in range(3):
+            client.post("/governance/advance/C12345")
+        r = client.get("/governance/board")
+        assert b'data-bc-id="C12345"' in r.data
+        assert b"kanban-reject-btn" in r.data
+
 
 class TestGovernanceExport:
     def test_export_returns_xlsx(self, client, app, sample_bc):
@@ -323,6 +338,21 @@ class TestSpecReject:
         assert r.status_code == 200
         data = r.get_json()
         assert data["status"] == "provisional"
+
+    def test_reject_from_published_returns_to_provisional(self, client, app, sample_spec):
+        for _ in range(3):
+            client.post(f"/governance/spec/advance/{sample_spec}")
+        client.post(f"/governance/spec/reject/{sample_spec}")
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, sample_spec)
+            assert spec.status == "provisional"
+
+    def test_board_shows_reject_button_for_published_spec(self, client, app, sample_spec):
+        for _ in range(3):
+            client.post(f"/governance/spec/advance/{sample_spec}")
+        r = client.get("/governance/board")
+        assert f'data-vlm-group-id="{sample_spec}"'.encode() in r.data
+        assert b"kanban-reject-btn" in r.data
 
     def test_reject_nonexistent_spec_returns_404(self, client):
         r = client.post("/governance/spec/reject/NOPE")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -205,6 +205,14 @@ class TestUpdateBc:
         with pytest.raises(ValueError, match="not found"):
             _dispatch("update_bc", {"bc_id": "NOPE", "short_name": "X"})
 
+    def test_blocked_when_published(self, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, sample_bc)
+            bc.status = "published"
+            db.session.commit()
+        with pytest.raises(ValueError, match="Ready to Publish"):
+            _dispatch("update_bc", {"bc_id": sample_bc, "short_name": "Renamed"})
+
 
 class TestMapNcit:
     def test_maps_and_audits(self, app, sample_bc):
@@ -213,6 +221,14 @@ class TestMapNcit:
         rows = _audit_rows(app, "ncit_mapped")
         assert len(rows) == 1
         assert rows[0].actor == "mcp"
+
+    def test_blocked_when_published(self, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, sample_bc)
+            bc.status = "published"
+            db.session.commit()
+        with pytest.raises(ValueError, match="Ready to Publish"):
+            _dispatch("map_ncit_to_bc", {"bc_id": sample_bc, "ncit_code": "C77777"})
 
     def test_promotes_import_id(self, app):
         with app.app_context():

--- a/tests/test_ncit.py
+++ b/tests/test_ncit.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
+from extensions import db
+from models.bc import BiomedicalConcept
 from services.ncit_api import NCItApiClient
 
 # ---------------------------------------------------------------------------
@@ -154,3 +156,28 @@ class TestNcitConceptRoute:
             r = client.get("/ncit/concept/CXXXXX")
 
         assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /ncit/resolve/<bc_id>
+# ---------------------------------------------------------------------------
+
+
+class TestNcitResolveRoute:
+    def test_maps_ncit_code_to_bc(self, client, app, sample_bc):
+        client.post("/ncit/resolve/C12345", data={"ncit_code": "C77777"})
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.ncit_code == "C77777"
+
+    def test_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            bc.status = "published"
+            db.session.commit()
+        r = client.post("/ncit/resolve/C12345", data={"ncit_code": "C77777"}, follow_redirects=True)
+        assert r.status_code == 200
+        assert b"Ready to Publish" in r.data
+        with app.app_context():
+            bc = db.session.get(BiomedicalConcept, "C12345")
+            assert bc.ncit_code == "C12345"

--- a/tests/test_specializations_routes.py
+++ b/tests/test_specializations_routes.py
@@ -167,6 +167,38 @@ class TestEditUpsert:
             assert spec.variables[0]["sdtm_variable"] == "RESULT"
             assert spec.variables[0]["data_type"] == "decimal"
 
+    def test_update_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DatasetSpecialization(vlm_group_id="VLM1", bc_id=sample_bc, domain="SDTM", short_name="Original", status="published"))
+            db.session.commit()
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM1", "bc_id": sample_bc, "domain": "CDASH", "short_name": "Renamed"},
+                follow_redirects=True,
+            )
+        assert resp.status_code == 200
+        assert b"Ready to Publish" in resp.data
+        with app.app_context():
+            spec = db.session.get(DatasetSpecialization, "VLM1")
+            assert spec.domain == "SDTM"
+            assert spec.short_name == "Original"
+
+    def test_new_vlm_group_id_still_creatable_when_other_specs_published(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DatasetSpecialization(vlm_group_id="VLM1", bc_id=sample_bc, domain="SDTM", short_name="Original", status="published"))
+            db.session.commit()
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.post(
+                "/specializations/",
+                data={"vlm_group_id": "VLM2", "bc_id": sample_bc, "domain": "CDASH", "short_name": "Brand New"},
+            )
+        assert resp.status_code == 302
+        with app.app_context():
+            assert db.session.get(DatasetSpecialization, "VLM2") is not None
+
     def test_edit_writes_updated_audit_log(self, client, app, sample_bc):
         with app.app_context():
             db.session.add(DatasetSpecialization(vlm_group_id="VLM1", bc_id=sample_bc, domain="SDTM", short_name="Original"))
@@ -213,6 +245,18 @@ class TestDelete:
         with patcher:
             resp = client.post("/specializations/NOPE/delete")
         assert resp.status_code == 404
+
+    def test_delete_blocked_when_published(self, client, app, sample_bc):
+        with app.app_context():
+            db.session.add(DatasetSpecialization(vlm_group_id="VLM1", bc_id=sample_bc, domain="SDTM", status="published"))
+            db.session.commit()
+        patcher, _ = _patch_client()
+        with patcher:
+            resp = client.post("/specializations/VLM1/delete", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b"Ready to Publish" in resp.data
+        with app.app_context():
+            assert db.session.get(DatasetSpecialization, "VLM1") is not None
 
 
 class TestDetail:


### PR DESCRIPTION
## Summary
- Once a BC or Dataset Specialization reaches the `published` ("Ready to Publish") governance status, editing and deleting are now refused — enforced in `services/bc_service.py`, `routes/bc.py`, `routes/ncit.py`, and `routes/specializations.py` (the service-layer guard is inherited automatically by the MCP `update_bc`/`map_ncit_to_bc` tools).
- The Governance board's Ready to Publish column previously rendered no action buttons at all, so there was no way to reject an item once it reached that stage even though reject already worked unconditionally from any status — added a working Reject button there for both BCs and specializations.
- `bc_detail.html`/`specializations.html` show a locked notice and disable the edit form/delete controls when published; the status is now labeled "Ready to Publish" consistently everywhere (it previously read "Published" on detail/list pages but "Ready to Publish" only on the Kanban board).
- The redundant "All Specializations" list card is now hidden when viewing a single specialization's page.

## Test plan
- [x] `pytest --tb=short` — 383 passed
- [x] `isort`/`black`/`flake8` clean (also enforced by pre-commit on this commit)
- [x] Manually drove a running server end-to-end for both a BC and a specialization: create → advance through all 4 governance stages → edit/delete blocked with lock notice → Reject via the new board button → edit/delete work again
- [x] Manually verified the "All Specializations" card shows on `/specializations/` but not on `/specializations/<vlm_group_id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #59 .
Closes #59 .