### PR TITLE
Add cdisc-bc-ncit-alignment submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cdisc-bc-ncit-alignment"]
+	path = cdisc-bc-ncit-alignment
+	url = https://github.com/pendingintent/cdisc-bc-ncit-alignment.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ target-version = ['py311', 'py312']
 [tool.isort]
 profile = "black"
 line_length = 200
+
+[tool.pytest.ini_options]
+addopts = "--ignore=cdisc-bc-ncit-alignment"


### PR DESCRIPTION
## Summary
- Adds `cdisc-bc-ncit-alignment` as a git submodule (pointed at its `main`, which includes pendingintent/cdisc-bc-ncit-alignment#4 — untracks generated artifacts/bytecode, pins requirements, drops dead code, adds CLI entry-point tests)
- Excludes the submodule from this repo's own pytest collection (`--ignore=cdisc-bc-ncit-alignment` in `pyproject.toml`), since its `tests/` package otherwise collides with this repo's `tests` package name and breaks the pre-commit hook

## Test plan
- [x] `pytest --tb=short` — 446 tests collected and passing, no collisions with the submodule's tests