### PR TITLE
Make release publish step resilient to a pre-existing release for the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" dist/*.zip dist/*.tar.gz --generate-notes
+        run: |
+          TAG="${{ github.ref_name }}"
+          # A release for this tag may already exist (e.g. someone drafted
+          # it manually in the GitHub UI when creating the tag) - in that
+          # case `gh release create` fails with "a release with the same
+          # tag name already exists" and this job's own dist/*.zip and
+          # .tar.gz never get attached, silently leaving only GitHub's
+          # auto-generated (submodule-less) source archive for users to
+          # download. Upload to the existing release instead when that
+          # happens.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/*.zip dist/*.tar.gz --clobber
+          else
+            gh release create "$TAG" dist/*.zip dist/*.tar.gz --generate-notes
+          fi

--- a/README-PROGRESS.md
+++ b/README-PROGRESS.md
@@ -32,6 +32,13 @@ CDISC Biomedical Concept Curation — a Flask/Jinja web application for curating
 
 ### 2026-09-03
 
+#### Fixed the Release Workflow Silently Publishing a Broken Archive When a Release Pre-Exists
+
+- A user reported the NCIt/BC Alignment feature failing with `populate_complete_list failed (exit code 1)` after installing from the `version-0.5` release download. Root cause: `cdisc-bc-ncit-alignment/` was completely empty in the archive they downloaded, so `python -m src.populate_complete_list` couldn't even be found.
+- Traced it to the actual `Release` workflow run for the `version-0.5` tag ([run 33779038795](https://github.com/pendingintent/cdisc-concept-curation/actions/runs/33779038795)): the submodule checkout and `scripts/build_release.py` packaging both succeeded (the produced zip/tar.gz were verified correct — submodule content present, no `.git`), but the final `gh release create` step failed with `a release with the same tag name already exists`, because a `version-0.5` release had already been drafted (via the GitHub UI, `createdAt` 2 minutes before the workflow ran) with zero assets. The job reported overall failure, but nobody was watching the Actions tab, so the release stayed live with only GitHub's auto-generated "Source code" zip/tarball — a plain `git archive` of the tag, which (as documented in `RELEASING.md` from the start) never resolves the submodule.
+- **Immediate remediation**: downloaded the already-correct `dist/*` artifact from that same failed run (`gh run download 33779038795 --name release-archives`), verified it contained real submodule files, and uploaded it directly to the existing `version-0.5` release (`gh release upload`) — the release's download links are now fixed with no re-tag needed.
+- **Root-cause fix**: `.github/workflows/release.yml`'s publish step now checks whether a release for the tag already exists (`gh release view`) and uploads to it (`gh release upload --clobber`) instead of unconditionally trying `gh release create`, which fails whenever one does. `RELEASING.md` updated to warn against drafting a release in the UI ahead of pushing the tag, and to check the Actions tab after pushing.
+
 #### Restricted the Release Workflow to `version-*` Tags Pushed From `main`
 
 - The release workflow (`.github/workflows/release.yml`) previously triggered on any `v*.*.*` tag pushed from anywhere. Per request: only run when the archive is cut from `main`, and use this project's actual tag convention (`version-` prefix, e.g. `version-1.2.3`), not semver `v`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,13 @@ branch will not produce a release.
    git tag version-1.2.3
    git push origin version-1.2.3
    ```
+   **Don't also draft a release for this tag in the GitHub UI first.** Push the tag
+   from the command line (or `git push --tags`) and let the workflow create the
+   release. If a release for the tag already exists, it just uploads the correct
+   assets to it instead of failing — but until that upload happens, the release page
+   would only offer GitHub's auto-generated "Source code" zip/tarball, which is a
+   plain `git archive` with no submodule content (see the warning above). Check the
+   **Actions** tab after pushing to confirm the `Release` workflow succeeded.
 2. The `Release` workflow checks out the repo (with the submodule fully resolved via
    `submodules: recursive`), confirms the tag is on `main`, runs
    `scripts/build_release.py`, and publishes a GitHub Release named `version-1.2.3`


### PR DESCRIPTION
## Summary
- A user installed from the `version-0.5` release download and got `populate_complete_list failed (exit code 1)` when running the NCIt/BC Alignment feature — `cdisc-bc-ncit-alignment/` was completely empty in the archive.
- Traced to [workflow run 33779038795](https://github.com/pendingintent/cdisc-concept-curation/actions/runs/33779038795): the submodule checkout and `scripts/build_release.py` packaging both succeeded (verified the produced zip/tar.gz have real submodule content, no `.git`), but the final `gh release create` step failed with `a release with the same tag name already exists` — a `version-0.5` release had already been drafted in the GitHub UI (with zero assets) before the tag push triggered this workflow. The job reported failure, but the release stayed live with only GitHub's auto-generated "Source code" zip/tarball, which is a plain `git archive` that never resolves the submodule.
- `.github/workflows/release.yml`'s publish step now checks `gh release view` first and uses `gh release upload --clobber` if a release already exists for the tag, falling back to `gh release create` otherwise — no longer assumes the release doesn't already exist.
- `RELEASING.md` updated to warn against drafting a release in the GitHub UI ahead of pushing the tag, and to check the Actions tab after pushing.
- Already remediated the live `version-0.5` release: downloaded the correct archives from the failed run's own workflow artifact and uploaded them directly (`gh release upload`) — that release's download links are fixed now, independent of this PR merging.

## Test plan
- [x] `pytest --tb=short` — 481 tests passing (no Python changes in this PR, only the workflow/docs)
- [x] Validated `.github/workflows/release.yml` parses as YAML
- [x] Verified the `version-0.5` release now has the correct `.zip`/`.tar.gz` assets attached with real submodule content
- [ ] Not verified: an actual re-run of the `Release` workflow against a pre-existing release (would require pushing a new test tag) — the `gh release view`/`upload`/`create` branching is straightforward but untested live in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)